### PR TITLE
Get attributes method for nodes (Refs: #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ use skyscraper::{html, xpath};
 let html_text = r##"
 <div>
     <div class="foo">
-        <span>yes</span>
+        <span some_attr="value">yes</span>
     </div>
     <div class="bar">
         <span>no</span>
@@ -74,4 +74,8 @@ assert_eq!(1, results.len());
 // Get text from the node
 let text = results[0].get_text(&document).expect("text missing");
 assert_eq!("yes", text);
+
+// Get attributes from the node
+let attributes = results[0].get_attributes(&document).expect("no attributes");
+assert_eq!("value", attributes["some_attr"]);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,11 @@
 //!     .ok_or_else(|| "text is missing")?;
 //!
 //! assert_eq!("Good info", text);
+//!
+//! // Assert that node class attribute is "duplicate" string.
+//! let attributes = nodes[0].get_attributes(&document).unwrap();
+//! assert_eq!("duplicate", attributes["class"]);
+//!
 //! # Ok(())
 //! # }
 //! ```

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -152,3 +152,23 @@ fn xpath_github_dashed_attribute() {
     // assert
     assert_eq!(19, nodes.len());
 }
+
+#[test]
+fn xpath_github_get_attributes_sample() {
+    // arrange
+    let text: String = HTML.parse().unwrap();
+
+    let document = html::parse(&text).unwrap();
+    let xpath = xpath::parse("//div[@class='flex-auto min-width-0 width-fit mr-3']").unwrap();
+
+    // act
+    let nodes = xpath.apply(&document).unwrap();
+
+    // assert
+    assert_eq!(1, nodes.len());
+
+    let doc_node = nodes[0];
+    let html_node = document.get_html_node(&doc_node).unwrap();
+    let attributes = html_node.get_attributes().unwrap();
+    assert_eq!("flex-auto min-width-0 width-fit mr-3", attributes["class"]);
+}


### PR DESCRIPTION
Added new method `get_attributes` for `HtmlTag` and `HtmlNode` types.