### PR TITLE
fix(html): Improve triangle bracket handling in text tokenizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyscraper"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["James La Novara-Gsell <james.lanovara.gsell@gmail.com>"]
 edition = "2018"
 description = "XPath for HTML web scraping"

--- a/src/html/parse.rs
+++ b/src/html/parse.rs
@@ -466,6 +466,46 @@ mod tests {
     }
 
     #[test]
+    fn parse_should_handle_text_with_triangle_brackets() {
+        // arrange
+        let html = r###"<div>foo > bar < baz</div>"###;
+
+        // act
+        let result = parse(html).unwrap();
+
+        // assert
+        // <div>
+        let key = result.root_node;
+        let children = assert_tag(&result, key, "div", None);
+
+        // <div> -> -> text()
+        {
+            let key = children[0];
+            assert_text(&result, key, "foo > bar < baz");
+        }
+    }
+
+    #[test]
+    fn parse_should_include_tag_like_text_in_script_tags() {
+        // arrange
+        let html = r###"<script>foo<bar></baz></script>"###;
+
+        // act
+        let result = parse(html).unwrap();
+
+        // assert
+        // <script>
+        let key = result.root_node;
+        let children = assert_tag(&result, key, "script", None);
+
+        // <script> -> -> text()
+        {
+            let key = children[0];
+            assert_text(&result, key, "foo<bar></baz>");
+        }
+    }
+
+    #[test]
     fn parse_should_handle_single_tags() {
         // arrange
         let html = r###"

--- a/src/xpath/mod.rs
+++ b/src/xpath/mod.rs
@@ -144,7 +144,7 @@ pub enum XpathAxes {
 impl XpathAxes {
     /// Returns the [XpathAxes] corresponding to the given `text`, or [None] if the string
     /// is not a known axis.
-    pub fn from_str(text: &str) -> Option<Self> {
+    pub fn try_from_str(text: &str) -> Option<Self> {
         match text {
             "parent" => Some(XpathAxes::Parent),
             "child" => Some(XpathAxes::Child),

--- a/src/xpath/parse.rs
+++ b/src/xpath/parse.rs
@@ -228,8 +228,8 @@ fn inner_parse(text: &str) -> Result<Vec<XpathElement>, ParseError> {
 fn parse_axis_selector(elements: &mut Vec<XpathElement>) -> Result<(), ParseError> {
     let last_item = elements.pop().ok_or(ParseError::MissingAxis)?;
     let axis = match last_item {
-        XpathElement::Tag(last_tag) => XpathAxes::from_str(last_tag.as_str())
-            .ok_or_else(|| ParseError::UnknownAxisType(last_tag))?,
+        XpathElement::Tag(last_tag) => XpathAxes::try_from_str(last_tag.as_str())
+            .ok_or(ParseError::UnknownAxisType(last_tag))?,
         _ => return Err(ParseError::MissingAxis),
     };
     elements.push(XpathElement::Axis(axis));


### PR DESCRIPTION
Script tags require special handling of triangle brackets to allow
them to be used as comparison operators in JS.

Closes #9