### PR TITLE
feat(html): Handle mismatched tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml"
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,13 @@ categories = ["parsing"]
 indextree = "4.3.1"
 lazy_static = "1.4.0"
 thiserror = "1.0.30"
-indexmap = "1.8.2"
+indexmap = "2.0.0"
+log = "0.4.19"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5.1"
+mockall = "0.11.4"
+indoc = "2"
 
 [[bench]]
 name = "benchmarks"

--- a/src/html/parse/malformed_html_handlers.rs
+++ b/src/html/parse/malformed_html_handlers.rs
@@ -1,0 +1,476 @@
+//! Methods for handling malformed HTML input.
+//!
+//! Methods are used by [Parser](crate::html::parse::Parser).
+//!
+//! See [ParseOptionsBuilder](crate::html::parse::parse_options::ParseOptionsBuilder)
+//! for details on how to select these handlers.
+
+use log::log;
+
+#[cfg(test)]
+use mockall::automock;
+
+use super::{ParseError, ParserState};
+
+/// Context given to a [MismatchedTagHandler].
+/// Includes the entire mutable [ParserState], plus some additional context.
+pub struct MismatchedTagHandlerContext<'a> {
+    /// The name of the open tag.
+    pub open_tag_name: &'a str,
+
+    /// The name of the close tag that did not match the open tag name.
+    pub close_tag_name: &'a str,
+
+    /// The mutable state of the parser when the tag mismatch was encountered.
+    pub parser_state: &'a mut ParserState,
+}
+
+/// Trait representing a method for handling a closing tag that does not have the same name as the corresponding opening tag.
+/// This happens when the HTML input is malformed.
+///
+/// Examples:
+///
+/// 1. End tag is incorrect:
+///
+///     ```html
+///     <html>
+///     </body> <!-- This should have been closing 'html'. -->
+///     ```
+///
+/// 2. End tag is missing entirely:
+///
+///     ```html
+///     <html>
+///       <div>
+///     </html> <!-- The closing 'div' is missing, which makes it seem like this 'html' closing tag is mismatched with the opening 'div'. -->
+///     ```
+#[cfg_attr(test, automock)]
+pub trait MismatchedTagHandler {
+    /// Performs the handling by (optionally) changing the [ParserState](crate::html::parse::ParserState).
+    ///
+    /// If the result is Ok, the parser will continue. If the result is Err, it will return the error immediately.
+    fn invoke<'a>(&self, context: MismatchedTagHandlerContext<'a>) -> Result<(), ParseError>;
+}
+
+/// Returns an error that an end tag did not match an opening tag.
+/// This cuts the parsing short and causes the parser to immediately return the error.
+pub struct ErrorMismatchedTagHandler {}
+
+impl ErrorMismatchedTagHandler {
+    /// Creates a new [ErrorMismatchedTagHandler].
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for ErrorMismatchedTagHandler {
+    fn default() -> Self {
+        ErrorMismatchedTagHandler::new()
+    }
+}
+
+impl MismatchedTagHandler for ErrorMismatchedTagHandler {
+    fn invoke(&self, context: MismatchedTagHandlerContext) -> Result<(), ParseError> {
+        Err(ParseError::EndTagMismatch {
+            end_name: context.close_tag_name.to_string(),
+            open_name: context.open_tag_name.to_string(),
+        })
+    }
+}
+
+/// Does not error, and performs no special handling, effectively ignoring the mismatching tag.
+/// Optionally logs a message that a tag mismatch has occurred.
+///
+/// ```rust
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// use skyscraper::html::parse::{Parser, ParseOptionsBuilder, malformed_html_handlers::VoidMismatchedTagHandler};
+/// let input = r#"
+///     <html>
+///         <body>
+///             hello
+///             <div>
+///                 there
+///         </body>
+///         friend
+///     </span>"#;
+///
+/// let options = ParseOptionsBuilder::new()
+///     .with_mismatched_tag_handler(Box::new(VoidMismatchedTagHandler::new(None)))
+///     .build();
+///
+/// let html = Parser::new(options).parse(input)?;
+///
+/// let output = r#"<html>
+///     <body>
+///         hello
+///         <div>
+///             there
+///         </div>
+///         friend
+///     </body>
+/// </html>
+/// "#;
+/// assert_eq!(html.to_string(), output);
+/// # Ok(())
+/// # }
+/// ```
+pub struct VoidMismatchedTagHandler {
+    log_level: Option<log::Level>,
+}
+
+impl VoidMismatchedTagHandler {
+    /// Creates a new [VoidMismatchedTagHandler].
+    ///
+    /// Set `log_level` to `None` if no logs are desired.
+    pub fn new(log_level: Option<log::Level>) -> Self {
+        Self { log_level }
+    }
+}
+
+impl MismatchedTagHandler for VoidMismatchedTagHandler {
+    fn invoke(&self, context: MismatchedTagHandlerContext) -> Result<(), ParseError> {
+        if let Some(log_level) = self.log_level {
+            log!(
+                log_level,
+                "End tag of {} mismatches opening tag of {}",
+                context.close_tag_name,
+                context.open_tag_name
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Attempts to close a missing tag by checking if the parent of the current tag matches the mismatching end tag.
+/// If the parent does not match, it ignores the mismatch without performing any additional handling, much like [VoidMismatchedTagHandler].
+///
+/// ```rust
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// use skyscraper::html::parse::{Parser, ParseOptionsBuilder, malformed_html_handlers::CloseMismatchedTagHandler};
+/// let input = r#"
+///     <html>
+///         <body>
+///             hello
+///             <div>
+///                 there
+///         </body>
+///         friend
+///     </span>"#;
+///
+/// let options = ParseOptionsBuilder::new()
+///     .with_mismatched_tag_handler(Box::new(CloseMismatchedTagHandler::new(None)))
+///     .build();
+///
+/// let html = Parser::new(options).parse(input)?;
+///
+/// let output = r#"<html>
+///     <body>
+///         hello
+///         <div>
+///             there
+///         </div>
+///     </body>
+///     friend
+/// </html>
+/// "#;
+/// assert_eq!(html.to_string(), output);
+/// # Ok(())
+/// # }
+/// ```
+pub struct CloseMismatchedTagHandler {
+    log_level: Option<log::Level>,
+}
+
+impl CloseMismatchedTagHandler {
+    /// Creates a new [CloseMismatchedTagHandler].
+    ///
+    /// Set `log_level` to `None` if no logs are desired.
+    pub fn new(log_level: Option<log::Level>) -> Self {
+        Self { log_level }
+    }
+}
+
+impl MismatchedTagHandler for CloseMismatchedTagHandler {
+    fn invoke(&self, context: MismatchedTagHandlerContext) -> Result<(), ParseError> {
+        if let Some(log_level) = self.log_level {
+            log!(
+                log_level,
+                "End tag of {} mismatches opening tag of {}",
+                context.close_tag_name,
+                context.open_tag_name
+            );
+        }
+
+        let cur_key = context
+            .parser_state
+            .arena
+            .get(context.parser_state.cur_key_o.unwrap())
+            .unwrap();
+
+        if let Some(parent_key) = cur_key.parent() {
+            // do not move up to the root node, otherwise the parser will attempt to move up past it.
+            if parent_key != context.parser_state.root_key_o.unwrap() {
+                let parent = context
+                    .parser_state
+                    .arena
+                    .get(parent_key)
+                    .unwrap()
+                    .get()
+                    .unwrap_tag();
+
+                // if the parent name matches the end tag of the mistmatch, assume the parent's end tag is missing and move up to close it.
+                // otherwise, ignore the mismatch and hope for the best.
+                if parent.name == context.close_tag_name {
+                    if let Some(log_level) = self.log_level {
+                        log!(
+                            log_level,
+                            "Parent tag matches end tag {}; assuming end tag is missing, closing current tag and parent tag",
+                            parent.name,
+                        );
+                    }
+                    context.parser_state.cur_key_o = Some(parent_key);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::*;
+    use crate::html::parse::{parse_options::ParseOptionsBuilder, Parser};
+
+    const HTML_MISMATCHED_END_TAG: &'static str = r#"
+        <html>
+            <body>
+                foo
+                <span>
+                    bar
+                </div>
+                <b>
+                    baz
+                </b>
+                bat
+            </body>
+            <footer>
+                foot
+            </footer>
+        </html>
+        "#;
+
+    const HTML_MISSING_END_TAG: &'static str = r#"
+        <html>
+            <body>
+                foo
+                <span>
+                    bar
+                    <b>
+                        baz
+                    </b>
+                    bat
+            </body>
+            <footer>
+                foot
+            </footer>
+        </html>
+        "#;
+
+    #[test]
+    fn error_handler_should_err_for_missing_end_tag() {
+        // arrange
+        let parse_options = ParseOptionsBuilder::new()
+            .with_mismatched_tag_handler(Box::new(ErrorMismatchedTagHandler::new()))
+            .build();
+        let parser = Parser::new(parse_options);
+
+        // act
+        let result = parser.parse(HTML_MISSING_END_TAG);
+
+        // assert
+        assert!(matches!(result, Err(ParseError::EndTagMismatch { .. })));
+
+        if let Err(ParseError::EndTagMismatch {
+            end_name,
+            open_name,
+        }) = result
+        {
+            assert_eq!(open_name, String::from("span"));
+            assert_eq!(end_name, String::from("body"));
+        }
+    }
+
+    #[test]
+    fn error_handler_should_err_for_mismatched_end_tag() {
+        // arrange
+        let parse_options = ParseOptionsBuilder::new()
+            .with_mismatched_tag_handler(Box::new(ErrorMismatchedTagHandler::new()))
+            .build();
+        let parser = Parser::new(parse_options);
+
+        // act
+        let result = parser.parse(HTML_MISMATCHED_END_TAG);
+
+        // assert
+        assert!(matches!(result, Err(ParseError::EndTagMismatch { .. })));
+
+        if let Err(ParseError::EndTagMismatch {
+            end_name,
+            open_name,
+        }) = result
+        {
+            assert_eq!(open_name, String::from("span"));
+            assert_eq!(end_name, String::from("div"));
+        }
+    }
+
+    #[test]
+    fn void_handler_should_ignore_mismatch_for_missing_end_tag() {
+        // arrange
+        let parse_options = ParseOptionsBuilder::new()
+            .with_mismatched_tag_handler(Box::new(VoidMismatchedTagHandler::new(None)))
+            .build();
+        let parser = Parser::new(parse_options);
+
+        // act
+        let result = parser.parse(HTML_MISSING_END_TAG).unwrap();
+
+        // assert
+        let output = result.to_string();
+        let expected_output = indoc!(
+            r#"
+            <html>
+                <body>
+                    foo
+                    <span>
+                        bar
+                        <b>
+                            baz
+                        </b>
+                        bat
+                    </span>
+                    <footer>
+                        foot
+                    </footer>
+                </body>
+            </html>
+            "#
+        );
+
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn void_handler_should_ignore_mismatch_for_mismatched_end_tag() {
+        // arrange
+        let parse_options = ParseOptionsBuilder::new()
+            .with_mismatched_tag_handler(Box::new(VoidMismatchedTagHandler::new(None)))
+            .build();
+        let parser = Parser::new(parse_options);
+
+        // act
+        let result = parser.parse(HTML_MISMATCHED_END_TAG).unwrap();
+
+        // assert
+        let output = result.to_string();
+        let expected_output = indoc!(
+            r#"
+            <html>
+                <body>
+                    foo
+                    <span>
+                        bar
+                    </span>
+                    <b>
+                        baz
+                    </b>
+                    bat
+                </body>
+                <footer>
+                    foot
+                </footer>
+            </html>
+            "#
+        );
+
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn close_handler_should_close_both_tags_for_missing_end_tag() {
+        // arrange
+        let parse_options = ParseOptionsBuilder::new()
+            .with_mismatched_tag_handler(Box::new(CloseMismatchedTagHandler::new(None)))
+            .build();
+        let parser = Parser::new(parse_options);
+
+        // act
+        let result = parser.parse(HTML_MISSING_END_TAG).unwrap();
+
+        // assert
+        let output = result.to_string();
+        let expected_output = indoc!(
+            r#"
+            <html>
+                <body>
+                    foo
+                    <span>
+                        bar
+                        <b>
+                            baz
+                        </b>
+                        bat
+                    </span>
+                </body>
+                <footer>
+                    foot
+                </footer>
+            </html>
+            "#
+        );
+
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn close_handler_should_ignore_mismatch_for_mismatched_end_tag() {
+        // arrange
+        let parse_options = ParseOptionsBuilder::new()
+            .with_mismatched_tag_handler(Box::new(CloseMismatchedTagHandler::new(None)))
+            .build();
+        let parser = Parser::new(parse_options);
+
+        // act
+        let result = parser.parse(HTML_MISMATCHED_END_TAG).unwrap();
+
+        // assert
+        let output = result.to_string();
+        let expected_output = indoc!(
+            r#"
+            <html>
+                <body>
+                    foo
+                    <span>
+                        bar
+                    </span>
+                    <b>
+                        baz
+                    </b>
+                    bat
+                </body>
+                <footer>
+                    foot
+                </footer>
+            </html>
+            "#
+        );
+
+        assert_eq!(output, expected_output);
+    }
+}

--- a/src/html/parse/parse_options.rs
+++ b/src/html/parse/parse_options.rs
@@ -1,0 +1,116 @@
+//! Create options for [parse_opts](super::parse_opts).
+
+use super::malformed_html_handlers::{ErrorMismatchedTagHandler, MismatchedTagHandler};
+
+/// Options for [parse_opts](super::parse_opts).
+pub struct ParseOptions {
+    /// Defines the method for handling an end tag that doesn't match the currently opened tag.
+    pub mismatched_tag_handler: Box<dyn MismatchedTagHandler>,
+}
+
+impl ParseOptions {
+    /// Create a new [ParseOptions] with default values.
+    pub fn new() -> Self {
+        Self {
+            mismatched_tag_handler: Box::new(ErrorMismatchedTagHandler::new()),
+        }
+    }
+}
+
+impl Default for ParseOptions {
+    fn default() -> Self {
+        ParseOptions::new()
+    }
+}
+
+/// Builds [ParseOptions] for the [Parser](crate::html::parse::Parser).
+///
+/// See [ParseOptions] for the default values used if not set by the builder.
+///
+/// Example usage:
+/// ```rust
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// use skyscraper::html::parse::{Parser, ParseOptionsBuilder, malformed_html_handlers::VoidMismatchedTagHandler};
+///
+/// let options = ParseOptionsBuilder::new()
+///     .with_mismatched_tag_handler(Box::new(VoidMismatchedTagHandler::new(None)))
+///     .build();
+///
+/// let parser = Parser::new(options);
+/// # Ok(())
+/// # }
+/// ```
+pub struct ParseOptionsBuilder {
+    reducers: Vec<Box<dyn FnOnce(ParseOptions) -> ParseOptions>>,
+}
+
+impl ParseOptionsBuilder {
+    /// Creates a new [ParseOptionsBuilder].
+    pub fn new() -> Self {
+        Self {
+            reducers: Vec::new(),
+        }
+    }
+
+    /// Set the type of [MismatchedTagHandler] the parser should use.
+    pub fn with_mismatched_tag_handler(mut self, handler: Box<dyn MismatchedTagHandler>) -> Self {
+        let reducer = |options| ParseOptions {
+            mismatched_tag_handler: handler,
+            ..options
+        };
+        self.reducers.push(Box::new(reducer));
+        self
+    }
+
+    /// Build the [ParseOptions].
+    pub fn build(self) -> ParseOptions {
+        self.reducers
+            .into_iter()
+            .fold(ParseOptions::new(), |options, f| f(options))
+    }
+}
+
+impl Default for ParseOptionsBuilder {
+    fn default() -> Self {
+        ParseOptionsBuilder::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::html::parse::{
+        malformed_html_handlers::{MismatchedTagHandlerContext, MockMismatchedTagHandler},
+        ParserState,
+    };
+
+    use super::*;
+
+    #[test]
+    fn with_mismatched_tag_handler_should_set_handler() {
+        // arrange
+        let builder = ParseOptionsBuilder::new();
+        let mut handler = MockMismatchedTagHandler::new();
+        let mut context = ParserState {
+            ..Default::default()
+        };
+        let context = MismatchedTagHandlerContext {
+            open_tag_name: "hi",
+            close_tag_name: "bye",
+            parser_state: &mut context,
+        };
+
+        handler.expect_invoke().times(1).returning(|_| Ok(()));
+
+        // act
+        let options = builder
+            .with_mismatched_tag_handler(Box::new(handler))
+            .build();
+
+        // assert
+        assert!(matches!(
+            options.mismatched_tag_handler.invoke(context),
+            Ok(())
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,42 +48,47 @@
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! # Example: use lazy_static if Xpath expressions are static
-//! 
+//!
 //! If your Xpath expressions are static, and you have a function that
 //! parses and applies the expression every time the function is called,
 //! consider using [mod@lazy_static] to prevent the expression from being
 //! repeatedly parsed.
-//! 
+//!
 //! ```rust
 //! #[macro_use]
 //! extern crate lazy_static;
-//! 
+//!
 //! use std::error::Error;
 //! use skyscraper::{html::{self, HtmlDocument}, xpath::{self, Xpath}};
-//! 
+//!
 //! lazy_static! {
 //!     static ref SPAN_XPATH: Xpath = xpath::parse("/div/span").unwrap();
 //! }
-//! 
+//!
 //! fn my_func(document: &HtmlDocument) -> Result<Option<String>, Box<dyn Error>> {
 //!     let xpath_results = SPAN_XPATH.apply(document)?;
 //!     Ok(xpath_results[0].get_text(document))
 //! }
-//! 
+//!
 //! fn main() -> Result<(), Box<dyn Error>> {
 //!     let doc1 = html::parse("<div><span>foo</span></div>")?;
 //!     let text1 = my_func(&doc1)?.expect("text missing");
 //!     assert_eq!("foo", text1);
-//! 
+//!
 //!     let doc2 = html::parse("<div><span>bar</span></div>")?;
 //!     let text2 = my_func(&doc2)?.expect("text missing");
 //!     assert_eq!("bar", text2);
-//! 
+//!
 //!     Ok(())
 //! }
 //! ```
+//!
+//! For more information on HTML documents and nodes, including how to get text or attributes from nodes,
+//! see the [html] module documentation.
+//!
+//! For more information on XPath expressions, see the [xpath] module documentation.
 
 #![warn(missing_docs)]
 

--- a/src/xpath/mod.rs
+++ b/src/xpath/mod.rs
@@ -1,5 +1,5 @@
 //! Parse and apply XPath expressions to HTML documents.
-//! 
+//!
 //! # Example: parse and apply an XPath expression.
 //! ```rust
 //! # use std::error::Error;
@@ -17,12 +17,12 @@
 //! </div>
 //! "##;
 //! let document = html::parse(html_text)?;
-//! 
+//!
 //! // Parse and apply the xpath.
 //! let expr = xpath::parse("//div[@class='foo']/span")?;
 //! let results = expr.apply(&document)?;
 //! assert_eq!(1, results.len());
-//! 
+//!
 //! // Get text from the node
 //! let text = results[0].get_text(&document).expect("text missing");
 //! assert_eq!("yes", text);
@@ -42,7 +42,7 @@ use thiserror::Error;
 pub use crate::xpath::parse::parse;
 
 /// Represents a set of additional conditions for a single XPath search.
-/// 
+///
 /// ```text
 /// //div[@class="node" @id="input"]
 ///       ^^^^^^^^^^^^^ ^^^^^^^^^^^
@@ -58,42 +58,42 @@ pub struct XpathQuery {
 #[derive(Debug, PartialEq, Clone)]
 pub enum XpathPredicate {
     /// Asserts that an attribute has a value greater than the given `value`.
-    /// 
+    ///
     /// Example: `price>3`
     GreaterThan {
         /// The attribute name.
         attribute: String,
         /// The value the attribute must be greater than.
-        value: u64
+        value: u64,
     },
 
     /// Asserts than an attribute has a value less than the given `value`.
-    /// 
+    ///
     /// Example: `price<3`
     LessThan {
         /// The attribute name.
         attribute: String,
         /// The value the attribute must be less than.
-        value: u64
+        value: u64,
     },
 
     /// Asserts than an attribute has a value equal to the given `value`.
-    /// 
+    ///
     /// Example: `id="input"`
     Equals {
         /// The attribute name.
         attribute: String,
         /// The value the attribute must be equal to.
-        value: String
+        value: String,
     },
 
     /// Combines two conditions with an 'and' relationship.
-    /// 
+    ///
     /// Example: `price>3 and price<5`
     And(Box<XpathPredicate>, Box<XpathPredicate>),
 
     ///Combines two conditions with an 'or' relationship.
-    /// 
+    ///
     /// Example: `price<3 or price>5`
     Or(Box<XpathPredicate>, Box<XpathPredicate>),
 }
@@ -129,9 +129,10 @@ impl XpathQuery {
 }
 
 /// XPath axes as defined in <https://www.w3.org/TR/2017/REC-xpath-31-20170321/#axes>.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Clone, Copy)]
 pub enum XpathAxes {
     /// Get direct children.
+    #[default]
     Child,
 
     /// Get all descendants and self.
@@ -149,14 +150,8 @@ impl XpathAxes {
             "parent" => Some(XpathAxes::Parent),
             "child" => Some(XpathAxes::Child),
             "descendent-or-self" => Some(XpathAxes::DescendantOrSelf),
-            _ => None
+            _ => None,
         }
-    }
-}
-
-impl Default for XpathAxes {
-    fn default() -> Self {
-        XpathAxes::Child
     }
 }
 
@@ -176,7 +171,7 @@ impl Default for XpathSearchNodeType {
 }
 
 /// Everything needed for a single XPath search
-/// 
+///
 /// ```text
 /// //div[@class="node"]/span
 /// ^-------------------^----
@@ -195,7 +190,7 @@ pub struct XpathSearchItem {
 }
 
 /// A full XPath expression.
-/// 
+///
 /// # Example: parse and apply an XPath expression.
 /// ```rust
 /// # use std::error::Error;
@@ -209,11 +204,11 @@ pub struct XpathSearchItem {
 /// </div>
 /// "##;
 /// let document = html::parse(html_text)?;
-/// 
+///
 /// // Parse and apply the xpath.
 /// let expr = xpath::parse("/div/span")?;
 /// let results = expr.apply(&document)?;
-/// 
+///
 /// assert_eq!(2, results.len());
 /// # Ok(())
 /// # }
@@ -225,12 +220,11 @@ pub struct Xpath {
 
 /// An error occurring while applying an [Xpath] expression
 /// to an [HtmlDocument].
-/// 
+///
 /// **Note:** Currently empty. Exists in case items are added
 /// while expanind Skyscraper feature set.
 #[derive(Error, Debug)]
-pub enum ApplyError {
-}
+pub enum ApplyError {}
 
 /// An ordered set of unique [DocumentNodes](DocumentNode).
 ///
@@ -242,27 +236,30 @@ pub struct DocumentNodeSet {
     /// `has_super_root` states that there is a fake node that we should pretend is included
     /// in `index_set`. It is defined as the parent of `document.root_node`. Its purpose
     /// is to facilitate the selection of `document.root_node` absolute path queries.
-    has_super_root: bool
+    has_super_root: bool,
 }
 
 impl From<IndexSet<DocumentNode>> for DocumentNodeSet {
     fn from(index_set: IndexSet<DocumentNode>) -> Self {
-        DocumentNodeSet { index_set, has_super_root: false }
+        DocumentNodeSet {
+            index_set,
+            has_super_root: false,
+        }
     }
 }
 
 impl DocumentNodeSet {
     /// Create a new empty [DocumentNodeSet].
-    /// 
+    ///
     /// Setting `has_super_root` includes a fake node dubbed the "super root" in this
     /// [DocumentNodeSet]. The super root node is defined as the parent of
     /// `document.root_node` and can be used to match the document's root node with a query.
-    /// 
+    ///
     /// See [search] for more information on using `has_super_root`.
     pub fn new(has_super_root: bool) -> DocumentNodeSet {
         DocumentNodeSet {
             index_set: Default::default(),
-            has_super_root
+            has_super_root,
         }
     }
 
@@ -401,15 +398,9 @@ fn apply_axis(
     searchable_nodes: &DocumentNodeSet,
 ) -> DocumentNodeSet {
     match axis {
-        XpathAxes::Child => {
-            get_all_children(document, searchable_nodes)
-        }
-        XpathAxes::DescendantOrSelf => {
-            get_all_descendants_or_self(document, searchable_nodes)
-        }
-        XpathAxes::Parent => {
-            get_all_parents(document, searchable_nodes)
-        }
+        XpathAxes::Child => get_all_children(document, searchable_nodes),
+        XpathAxes::DescendantOrSelf => get_all_descendants_or_self(document, searchable_nodes),
+        XpathAxes::Parent => get_all_parents(document, searchable_nodes),
     }
 }
 
@@ -437,7 +428,11 @@ fn get_all_descendants_or_self(
     document: &HtmlDocument,
     matched_nodes: &DocumentNodeSet,
 ) -> DocumentNodeSet {
-    fn internal_get_all_descendants_or_self(node_id: DocumentNode, document: &HtmlDocument, descendant_or_self_nodes: &mut DocumentNodeSet) {
+    fn internal_get_all_descendants_or_self(
+        node_id: DocumentNode,
+        document: &HtmlDocument,
+        descendant_or_self_nodes: &mut DocumentNodeSet,
+    ) {
         descendant_or_self_nodes.insert(node_id);
         let mut children: DocumentNodeSet = node_id.children(document).collect();
         if !children.is_empty() {
@@ -452,7 +447,11 @@ fn get_all_descendants_or_self(
         // Pretend a super root item *above* the official document root is included
         // in the given matched_nodes. Meaning we must now move down to the official document
         // root as it is a child of the super root.
-        internal_get_all_descendants_or_self(document.root_node, document, &mut descendant_or_self_nodes);
+        internal_get_all_descendants_or_self(
+            document.root_node,
+            document,
+            &mut descendant_or_self_nodes,
+        );
     }
 
     for node_id in matched_nodes {
@@ -478,7 +477,7 @@ fn get_all_parents(document: &HtmlDocument, matched_nodes: &DocumentNodeSet) -> 
 }
 
 /// Search for an HTML tag matching the given search parameters in the given list of nodes.
-/// 
+///
 /// # Example: search for a root node using `has_super_root`
 /// ```rust
 /// # use std::error::Error;
@@ -492,7 +491,7 @@ fn get_all_parents(document: &HtmlDocument, matched_nodes: &DocumentNodeSet) -> 
 /// </div>
 /// "##;
 /// let document = html::parse(html_text)?;
-/// 
+///
 /// let search_params = XpathSearchItem {
 ///     search_node_type: XpathSearchNodeType::Element(String::from("div")),
 ///     ..Default::default()
@@ -502,23 +501,23 @@ fn get_all_parents(document: &HtmlDocument, matched_nodes: &DocumentNodeSet) -> 
 ///     &document,
 ///     &DocumentNodeSet::new(true),
 /// ).unwrap();
-/// 
+///
 /// assert_eq!(1, result.len());
-/// 
+///
 /// let html_node = document.get_html_node(&result[0]).unwrap();
 /// let tag = html_node.unwrap_tag();
 /// assert_eq!("div", tag.name);
-/// 
+///
 /// # Ok(())
 /// # }
 /// ```
-/// 
+///
 /// # Example: search for child nodes node by starting from specified node
 /// ```rust
 /// # use std::error::Error;
 /// #[macro_use]
 /// extern crate indexmap;
-/// 
+///
 /// use skyscraper::{html, xpath::{self, XpathSearchItem, XpathSearchNodeType, DocumentNodeSet}};
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// // Parse the html text into a document.
@@ -529,7 +528,7 @@ fn get_all_parents(document: &HtmlDocument, matched_nodes: &DocumentNodeSet) -> 
 /// </div>
 /// "##;
 /// let document = html::parse(html_text)?;
-/// 
+///
 /// let search_params = XpathSearchItem {
 ///     search_node_type: XpathSearchNodeType::Element(String::from("span")),
 ///     ..Default::default()
@@ -539,17 +538,17 @@ fn get_all_parents(document: &HtmlDocument, matched_nodes: &DocumentNodeSet) -> 
 ///     &document,
 ///     &DocumentNodeSet::from(indexset![document.root_node]),
 /// ).unwrap();
-/// 
+///
 /// assert_eq!(2, result.len());
-/// 
+///
 /// # Ok(())
 /// # }
 /// ```
-/// 
+///
 /// # Example: searching with an index and axis
 /// ```rust
 /// # use std::error::Error;
-/// 
+///
 /// use skyscraper::{html, xpath::{self, XpathSearchItem, XpathSearchNodeType, DocumentNodeSet, XpathAxes}};
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// // Parse the html text into a document.
@@ -560,7 +559,7 @@ fn get_all_parents(document: &HtmlDocument, matched_nodes: &DocumentNodeSet) -> 
 /// </div>
 /// "##;
 /// let document = html::parse(html_text)?;
-/// 
+///
 /// let search_params = XpathSearchItem {
 ///     search_node_type: XpathSearchNodeType::Element(String::from("span")),
 ///     axis: XpathAxes::DescendantOrSelf,
@@ -572,29 +571,25 @@ fn get_all_parents(document: &HtmlDocument, matched_nodes: &DocumentNodeSet) -> 
 ///     &document,
 ///     &DocumentNodeSet::new(true),
 /// ).unwrap();
-/// 
+///
 /// assert_eq!(1, result.len());
-/// 
+///
 /// let html_node = document.get_html_node(&result[0]).unwrap();
 /// let tag = html_node.unwrap_tag();
 /// assert_eq!("span", tag.name);
-/// 
+///
 /// let text = result[0].get_text(&document).unwrap();
 /// assert_eq!("world", text);
-/// 
+///
 /// # Ok(())
 /// # }
 /// ```
 pub fn search(
     search_item: &XpathSearchItem,
     document: &HtmlDocument,
-    searchable_nodes: &DocumentNodeSet
+    searchable_nodes: &DocumentNodeSet,
 ) -> Result<DocumentNodeSet, ApplyError> {
-    let searchable_nodes = apply_axis(
-        document,
-        &search_item.axis,
-        searchable_nodes,
-    );
+    let searchable_nodes = apply_axis(document, &search_item.axis, searchable_nodes);
 
     let mut matches = DocumentNodeSet::new(searchable_nodes.has_super_root);
 
@@ -612,12 +607,12 @@ pub fn search(
                                 matches.insert(*node_id);
                             }
                         }
-                    },
+                    }
                     HtmlNode::Text(_) => continue,
                 },
                 XpathSearchNodeType::Any => {
                     matches.insert(*node_id);
-                },
+                }
             }
         }
     }
@@ -653,12 +648,7 @@ mod test {
             search_node_type: XpathSearchNodeType::Element(String::from("root")),
             ..Default::default()
         };
-        let result = search(
-            &search_params,
-            &document,
-            &DocumentNodeSet::new(true),
-        )
-        .unwrap();
+        let result = search(&search_params, &document, &DocumentNodeSet::new(true)).unwrap();
 
         assert_eq!(1, result.len());
         let node = document.get_html_node(&result[0]).unwrap();
@@ -684,12 +674,7 @@ mod test {
             index: Some(2),
             ..Default::default()
         };
-        let result = search(
-            &search_params,
-            &document,
-            &DocumentNodeSet::new(true),
-        )
-        .unwrap();
+        let result = search(&search_params, &document, &DocumentNodeSet::new(true)).unwrap();
 
         assert_eq!(1, result.len());
         let node = document.get_html_node(&result[0]).unwrap();
@@ -718,12 +703,7 @@ mod test {
             axis: XpathAxes::DescendantOrSelf,
             ..Default::default()
         };
-        let result = search(
-            &search_params,
-            &document,
-            &DocumentNodeSet::new(true),
-        )
-        .unwrap();
+        let result = search(&search_params, &document, &DocumentNodeSet::new(true)).unwrap();
 
         assert_eq!(3, result.len());
 
@@ -759,12 +739,7 @@ mod test {
             query: Some(query),
             ..Default::default()
         };
-        let result = search(
-            &search_params,
-            &document,
-            &DocumentNodeSet::new(true),
-        )
-        .unwrap();
+        let result = search(&search_params, &document, &DocumentNodeSet::new(true)).unwrap();
 
         assert_eq!(1, result.len());
 
@@ -805,12 +780,7 @@ mod test {
             query: Some(query),
             ..Default::default()
         };
-        let result = search(
-            &search_params,
-            &document,
-            &DocumentNodeSet::new(true),
-        )
-        .unwrap();
+        let result = search(&search_params, &document, &DocumentNodeSet::new(true)).unwrap();
 
         assert_eq!(1, result.len());
 

--- a/src/xpath/tokenizer/helpers.rs
+++ b/src/xpath/tokenizer/helpers.rs
@@ -168,10 +168,10 @@ pub fn is_double_colon(pointer: &mut VecPointerRef<char>) -> Option<Token> {
 /// If true it will move the text pointer to the next symbol, otherwise it will not change the pointer.
 pub fn is_number(pointer: &mut VecPointerRef<char>) -> Option<Token> {
     if let Some(c) = pointer.current() {
-        if c.is_digit(10) {
+        if c.is_ascii_digit() {
             let mut num = c.to_string();
             while let Some(c) = pointer.next() {
-                if c.is_digit(10) {
+                if c.is_ascii_digit() {
                     num.push(*c);
                 } else {
                     break;
@@ -182,7 +182,7 @@ pub fn is_number(pointer: &mut VecPointerRef<char>) -> Option<Token> {
             if let Some('.') = pointer.current() {
                 num.push('.');
                 while let Some(c) = pointer.next() {
-                    if c.is_digit(10) {
+                    if c.is_ascii_digit() {
                         num.push(*c);
                     } else {
                         break;


### PR DESCRIPTION
- Adds an extension point for handling mismatched tags in malformed HTML
- Adds several mismatched tag handlers
- Implements Display on HtmlDocument

Fixes #13