### PR TITLE
Check if search index out of bounds

### DIFF
--- a/src/xpath/search.rs
+++ b/src/xpath/search.rs
@@ -148,8 +148,11 @@ pub fn search(
 
     // Apply indexing if required
     if let Some(i) = search_item.index {
-        let indexed_node = matches[i - 1];
-        matches.retain(|node| *node == indexed_node);
+        
+        if i < matches.len() {
+            let indexed_node = matches[i - 1];
+            matches.retain(|node| *node == indexed_node);
+        }
     }
 
     Ok(matches)

--- a/src/xpath/search.rs
+++ b/src/xpath/search.rs
@@ -148,7 +148,6 @@ pub fn search(
 
     // Apply indexing if required
     if let Some(i) = search_item.index {
-        
         if i < matches.len() {
             let indexed_node = matches[i - 1];
             matches.retain(|node| *node == indexed_node);

--- a/src/xpath/search.rs
+++ b/src/xpath/search.rs
@@ -148,9 +148,11 @@ pub fn search(
 
     // Apply indexing if required
     if let Some(i) = search_item.index {
-        if i < matches.len() {
+        if i <= matches.len() { // XPath index is 1-based
             let indexed_node = matches[i - 1];
             matches.retain(|node| *node == indexed_node);
+        } else {
+            return Ok(DocumentNodeSet::new(searchable_nodes.has_super_root));
         }
     }
 


### PR DESCRIPTION
**Problem**

Let's assume I want to search for a **strong[1]**, with a parent node **//div**, but some of the divs don't have it. As the search is implemented right now, the [code](https://github.com/James-LG/Skyscraper/blob/master/src/xpath/search.rs#L151) will just panic, since it does not handle out of bound indexing.

**Solution**
Just add a simple check on the search index. I didn't fix it [deeper, at the DocumentNodeSet level](https://github.com/James-LG/Skyscraper/blob/master/src/xpath/mod.rs#L415), since raw indexing is heavily used in a lot of places and would require more effort.