### PR TITLE
feat: Support the contains function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+test.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyscraper"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["James La Novara-Gsell <james.lanovara.gsell@gmail.com>"]
 edition = "2021"
 description = "XPath for HTML web scraping"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Below is a non-exhaustive list of all the features that are currently supported.
     1. Indexing: `//div[1]`
 1. Functions:
     1. `fn:root()`
+    1. `contains(haystack, needle)`
 1. Forward axes:
     1. Child: `child::*`
     1. Descendant: `descendant::*`

--- a/src/xpath/grammar/expressions/common.rs
+++ b/src/xpath/grammar/expressions/common.rs
@@ -2,7 +2,11 @@ use std::fmt::Display;
 
 use nom::{branch::alt, character::complete::char, combinator::opt, error::context, multi::many0};
 
-use crate::xpath::grammar::{expressions::expr_single, recipes::Res, whitespace_recipes::ws};
+use crate::xpath::{
+    grammar::{expressions::expr_single, recipes::Res, whitespace_recipes::ws},
+    xpath_item_set::XpathItemSet,
+    ExpressionApplyError, XpathExpressionContext,
+};
 
 use super::ExprSingle;
 
@@ -72,6 +76,18 @@ impl Display for Argument {
         match self {
             Argument::ExprSingle(x) => write!(f, "{}", x),
             Argument::ArgumentPlaceHolder => write!(f, "?"),
+        }
+    }
+}
+
+impl Argument {
+    pub(crate) fn eval<'tree>(
+        &self,
+        context: &XpathExpressionContext<'tree>,
+    ) -> Result<XpathItemSet<'tree>, ExpressionApplyError> {
+        match &self {
+            Argument::ExprSingle(expr_single) => expr_single.eval(context),
+            Argument::ArgumentPlaceHolder => todo!("Argument::ArgumentPlaceHolder eval"),
         }
     }
 }

--- a/src/xpath/grammar/expressions/comparison_expressions.rs
+++ b/src/xpath/grammar/expressions/comparison_expressions.rs
@@ -22,7 +22,10 @@ use crate::{
     xpath_item_set,
 };
 
-use super::string_concat_expressions::StringConcatExpr;
+use super::{
+    primary_expressions::static_function_calls::func_data,
+    string_concat_expressions::StringConcatExpr,
+};
 
 pub fn comparison_expr(input: &str) -> Res<&str, ComparisonExpr> {
     // https://www.w3.org/TR/2017/REC-xpath-31-20170321/#prod-xpath31-ComparisonExpr
@@ -128,42 +131,6 @@ impl ComparisonExpr {
             AnyAtomicType::Boolean(bool_value),
         )])
     }
-}
-
-/// https://www.w3.org/TR/2017/REC-xpath-31-20170321/#dt-atomization
-fn func_data<'tree>(
-    set: &XpathItemSet<'tree>,
-    item_tree: &'tree XpathItemTree,
-) -> Vec<AnyAtomicType> {
-    fn atomize<'tree>(item: &XpathItem, item_tree: &'tree XpathItemTree) -> AnyAtomicType {
-        match item {
-            XpathItem::Node(node) => match node {
-                Node::TreeNode(tree_node) => match tree_node.data {
-                    XpathItemTreeNodeData::DocumentNode(_) => {
-                        AnyAtomicType::String(tree_node.all_text(item_tree))
-                    }
-                    XpathItemTreeNodeData::ElementNode(_) => {
-                        AnyAtomicType::String(tree_node.all_text(item_tree))
-                    }
-                    XpathItemTreeNodeData::PINode(_) => todo!("func_data PINode"),
-                    XpathItemTreeNodeData::CommentNode(_) => todo!("func_data CommentNode"),
-                    XpathItemTreeNodeData::TextNode(text) => {
-                        AnyAtomicType::String(text.content.clone())
-                    }
-                },
-                Node::NonTreeNode(non_tree_node) => match non_tree_node {
-                    NonTreeXpathNode::AttributeNode(attribute) => {
-                        AnyAtomicType::String(attribute.value.clone())
-                    }
-                    NonTreeXpathNode::NamespaceNode(_) => todo!("func_data NamespaceNode"),
-                },
-            },
-            XpathItem::Function(_) => todo!("func_data Function"),
-            XpathItem::AnyAtomicType(atomic) => atomic.clone(),
-        }
-    }
-
-    set.iter().map(|item| atomize(item, item_tree)).collect()
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/src/xpath/grammar/expressions/primary_expressions/mod.rs
+++ b/src/xpath/grammar/expressions/primary_expressions/mod.rs
@@ -43,7 +43,7 @@ mod inline_function_expressions;
 mod literals;
 mod named_function_references;
 pub mod parenthesized_expressions;
-mod static_function_calls;
+pub mod static_function_calls;
 pub mod variable_references;
 
 pub fn primary_expr(input: &str) -> Res<&str, PrimaryExpr> {

--- a/tests/contains_tests.rs
+++ b/tests/contains_tests.rs
@@ -1,0 +1,135 @@
+use skyscraper::{
+    html::{self, trim_internal_whitespace},
+    xpath,
+};
+
+#[test]
+fn contains_should_select_text() {
+    // arrange
+    let text = r###"
+        <html>
+            <div>
+                hello world
+            </div>
+            <div>
+                select me
+            </div>
+        </html>"###;
+
+    let document = html::parse(&text).unwrap();
+    let xpath_item_tree = xpath::XpathItemTree::from(&document);
+    let xpath = xpath::parse("//div[contains(text(),'select')]").unwrap();
+
+    // act
+    let nodes = xpath.apply(&xpath_item_tree).unwrap();
+
+    // assert
+    assert_eq!(nodes.len(), 1);
+    let mut nodes = nodes.into_iter();
+
+    // assert node
+    {
+        let tree_node = nodes
+            .next()
+            .unwrap()
+            .extract_into_node()
+            .extract_into_tree_node();
+
+        let element = tree_node.data.extract_as_element_node();
+        assert_eq!(element.name, "div");
+
+        assert_eq!(
+            trim_internal_whitespace(&tree_node.text(&xpath_item_tree).unwrap()),
+            "select me"
+        );
+    }
+}
+
+#[test]
+fn contains_should_select_attribute() {
+    // arrange
+    let text = r###"
+        <html>
+            <div class="nah">
+                hello world
+            </div>
+            <div class="select me">
+                select me
+            </div>
+        </html>"###;
+
+    let document = html::parse(&text).unwrap();
+    let xpath_item_tree = xpath::XpathItemTree::from(&document);
+    let xpath = xpath::parse("//div[contains(@class,'select')]").unwrap();
+
+    // act
+    let nodes = xpath.apply(&xpath_item_tree).unwrap();
+
+    // assert
+    assert_eq!(nodes.len(), 1);
+    let mut nodes = nodes.into_iter();
+
+    // assert node
+    {
+        let tree_node = nodes
+            .next()
+            .unwrap()
+            .extract_into_node()
+            .extract_into_tree_node();
+
+        let element = tree_node.data.extract_as_element_node();
+        assert_eq!(element.name, "div");
+
+        assert_eq!(
+            trim_internal_whitespace(&tree_node.text(&xpath_item_tree).unwrap()),
+            "select me"
+        );
+    }
+}
+
+#[test]
+fn contains_should_select_on_expression() {
+    // arrange
+    let text = r###"
+        <html>
+            <div>
+                other
+            </div>
+            <div>
+                hello world
+            </div>
+            <div class="hello" id="select"></div>
+        
+        </html>"###;
+
+    let document = html::parse(&text).unwrap();
+    let xpath_item_tree = xpath::XpathItemTree::from(&document);
+
+    // this expression first selects the class attribute of the div with id 'select',
+    // then uses that result to find a div with text containing that class.
+    let xpath = xpath::parse("//div[contains(text(),//div[@id='select']/@class)]").unwrap();
+
+    // act
+    let nodes = xpath.apply(&xpath_item_tree).unwrap();
+
+    // assert
+    assert_eq!(nodes.len(), 1);
+    let mut nodes = nodes.into_iter();
+
+    // assert node
+    {
+        let tree_node = nodes
+            .next()
+            .unwrap()
+            .extract_into_node()
+            .extract_into_tree_node();
+
+        let element = tree_node.data.extract_as_element_node();
+        assert_eq!(element.name, "div");
+
+        assert_eq!(
+            trim_internal_whitespace(&tree_node.text(&xpath_item_tree).unwrap()),
+            "hello world"
+        );
+    }
+}

--- a/tests/lxml_tests/README.md
+++ b/tests/lxml_tests/README.md
@@ -1,0 +1,11 @@
+# LXML test project
+
+This project is used to test the accepted behaviour of Xpath expressions.
+
+## Usage
+
+From the root of the repo, you can create a `test.html` file and pipe it into this Python program along with an Xpath expression as an argument.
+
+```sh
+cat test.html | python3 tests/lxml_tests/xpath.py "//div[contains(text(),//div[#id='select']/@class)]"
+```


### PR DESCRIPTION
Adds support for the `contains(haystack, needle)` function as defined by https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/contains

e.g. `//div[contains(text(),'select')]`

Closes #29.