### PR TITLE
refactor(xpath)!: Simplify data model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyscraper"
-version = "0.6.4"
+version = "0.7.0-beta.0"
 authors = ["James La Novara-Gsell <james.lanovara.gsell@gmail.com>"]
 edition = "2021"
 description = "XPath for HTML web scraping"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,14 +40,14 @@
 //! assert_eq!(items.len(), 1);
 //!
 //! // Compare the text of the first and only node returned by the XPath expression
-//! let node = items[0].extract_as_node().extract_as_tree_node();
+//! let node = items[0].extract_as_node();
 //! let text = node.text(&xpath_item_tree).unwrap();
 //!
 //! assert_eq!(text, "Good info");
 //!
 //! // Assert that node class attribute is "duplicate" string.
-//! let element = node.data.extract_as_element_node();
-//! let attribute = element.get_attribute("class").unwrap();
+//! let element = node.extract_as_element_node();
+//! let attribute = element.get_attribute(&xpath_item_tree, "class").unwrap();
 //! assert_eq!(attribute, "duplicate");
 //!
 //! # Ok(())
@@ -73,7 +73,7 @@
 //!     let result = SPAN_XPATH.apply(&xpath_item_tree)?;
 //!
 //!     let items = result;
-//!     let node = items[0].extract_as_node().extract_as_tree_node();
+//!     let node = items[0].extract_as_node();
 //!     Ok(node.text(&xpath_item_tree).unwrap())
 //! }
 //!

--- a/src/xpath/grammar/data_model/mod.rs
+++ b/src/xpath/grammar/data_model/mod.rs
@@ -3,6 +3,7 @@
 use std::fmt::Display;
 
 use enum_extract_macro::EnumExtract;
+use indextree::NodeId;
 use ordered_float::OrderedFloat;
 
 use super::{NonTreeXpathNode, XpathItemTreeNode};
@@ -123,6 +124,12 @@ impl Display for XpathDocumentNode {
 ///  https://www.w3.org/TR/xpath-datamodel-31/#ElementNode
 #[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 pub struct ElementNode {
+    /// The ID of the element.
+    ///
+    /// Optional to enable construction of the tree before assigning IDs.
+    /// Can be considered always Some in a valid tree.
+    id: Option<NodeId>,
+
     /// The name of the element.
     pub name: String,
 
@@ -141,6 +148,25 @@ impl Display for ElementNode {
 }
 
 impl ElementNode {
+    /// Create a new element node.
+    pub(crate) fn new(name: String, attributes: Vec<AttributeNode>) -> Self {
+        Self {
+            id: None,
+            name,
+            attributes,
+        }
+    }
+
+    /// Set the ID of the element.
+    pub(crate) fn set_id(&mut self, id: NodeId) {
+        self.id = Some(id);
+    }
+
+    /// Get the ID of the element.
+    pub(crate) fn id(&self) -> NodeId {
+        self.id.unwrap()
+    }
+
     /// Get the value of an attribute.
     ///
     /// # Arguments
@@ -216,11 +242,38 @@ impl Display for CommentNode {
 /// https://www.w3.org/TR/xpath-datamodel-31/#TextNode
 #[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Hash, Clone)]
 pub struct TextNode {
+    /// The ID of the text node.
+    ///
+    /// Optional to enable construction of the tree before assigning IDs.
+    /// Can be considered always Some in a valid tree.
+    id: Option<NodeId>,
+
     /// The value of the text node.
     pub content: String,
 
     /// Whether the text node contains only whitespace.
     pub only_whitespace: bool,
+}
+
+impl TextNode {
+    /// Create a new text node.
+    pub(crate) fn new(content: String, only_whitespace: bool) -> Self {
+        Self {
+            id: None,
+            content,
+            only_whitespace,
+        }
+    }
+
+    /// Set the ID of the text node.
+    pub(crate) fn set_id(&mut self, id: NodeId) {
+        self.id = Some(id);
+    }
+
+    /// Get the ID of the text node.
+    pub(crate) fn id(&self) -> NodeId {
+        self.id.unwrap()
+    }
 }
 
 impl Display for TextNode {

--- a/src/xpath/grammar/data_model/mod.rs
+++ b/src/xpath/grammar/data_model/mod.rs
@@ -83,19 +83,39 @@ impl Display for Function {
 pub struct XpathDocumentNode {}
 
 impl XpathDocumentNode {
-    pub fn all_text<'tree>(&self, tree: &'tree XpathItemTree) -> String {
+    /// Get all text contained in this element and its descendants.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - The tree that this document is a part of.
+    ///
+    /// # Returns
+    ///
+    /// A string of all text contained in this document and its descendants.
+    pub fn text_content<'tree>(&self, tree: &'tree XpathItemTree) -> String {
         let strings: Vec<String> = tree
             .root_node
             .children(&tree.arena)
             .into_iter()
             .map(|x| tree.get(x))
-            .map(|x| x.all_text(tree))
+            .map(|x| x.text_content(tree))
             .collect();
 
         let text = strings.join("");
         text
     }
 
+    /// Text before the first subelement. This is either a string or the value None, if there was no text.
+    ///
+    /// Use [`XpathDocumentNode::text_content`] to get all text _including_ text in descendant nodes.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - The tree that this document is a part of.
+    ///
+    /// # Returns
+    ///
+    /// A string of all text contained in this document.
     pub fn text<'tree>(&self, tree: &'tree XpathItemTree) -> Option<String> {
         let strings: Vec<String> = tree
             .root_node
@@ -109,6 +129,15 @@ impl XpathDocumentNode {
         strings.into_iter().next()
     }
 
+    /// Get all children of the document.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - The tree containing the document.
+    ///
+    /// # Returns
+    ///
+    /// A vector of all children of the document.
     pub fn children<'tree>(&self, tree: &'tree XpathItemTree) -> Vec<&'tree XpathItemTreeNodeData> {
         tree.root_node
             .children(&tree.arena)
@@ -236,8 +265,6 @@ impl ElementNode {
 
     /// Get all text contained in this element and its descendants.
     ///
-    /// Use [`ElementNode::text`] to get _only_ text contained directly in this node.
-    ///
     /// # Arguments
     ///
     /// * `tree` - The tree that this element is a part of.
@@ -245,21 +272,13 @@ impl ElementNode {
     /// # Returns
     ///
     /// A string of all text contained in this element and its descendants.
-    pub fn all_text<'tree>(&self, tree: &'tree XpathItemTree) -> String {
-        let strings: Vec<String> =
-            // Get all children.
-            Self::get_all_text_nodes(tree, self, true)
-            .into_iter()
-            .map(|x| x.content)
-            .collect();
-
-        let text = strings.join("");
-        text
+    pub fn text_content<'tree>(&self, tree: &'tree XpathItemTree) -> String {
+        self.itertext(tree).collect::<Vec<String>>().join("")
     }
 
-    /// Get text directly contained in this element.
+    /// Text before the first subelement. This is either a string or the value None, if there was no text.
     ///
-    /// Use [`ElementNode::all_text`] to get all text _including_ text in descendant nodes.
+    /// Use [`ElementNode::text_content`] to get all text _including_ text in descendant nodes.
     ///
     /// # Arguments
     ///

--- a/src/xpath/grammar/expressions/expressions_on_sequence_types/treat.rs
+++ b/src/xpath/grammar/expressions/expressions_on_sequence_types/treat.rs
@@ -72,11 +72,7 @@ impl TreatExpr {
 
         if !treat_type.is_match(&result)? {
             return Err(ExpressionApplyError {
-                msg: format!(
-                    "err:XPDY0050 Cannot treat {} as {}",
-                    result,
-                    treat_type.to_string()
-                ),
+                msg: format!("err:XPDY0050 Cannot treat as {}", treat_type.to_string()),
             });
         }
 

--- a/src/xpath/grammar/expressions/mod.rs
+++ b/src/xpath/grammar/expressions/mod.rs
@@ -20,10 +20,7 @@ use self::{
     logical_expressions::OrExpr, quantified_expressions::QuantifiedExpr,
 };
 
-use super::{
-    data_model::{Node, XpathItem},
-    recipes::Res,
-};
+use super::{data_model::XpathItem, recipes::Res};
 
 pub mod arithmetic_expressions;
 pub mod arrow_operator;
@@ -81,7 +78,7 @@ impl Xpath {
     ///
     /// ```rust
     /// use skyscraper::html;
-    /// use skyscraper::xpath::{self, XpathItemTree, grammar::{XpathItemTreeNodeData, data_model::{Node, XpathItem}}};
+    /// use skyscraper::xpath::{self, XpathItemTree, grammar::{XpathItemTreeNodeData, data_model::XpathItem}};
     /// use std::error::Error;
     ///
     /// fn main() -> Result<(), Box<dyn Error>> {
@@ -108,8 +105,6 @@ impl Xpath {
     ///
     ///     let element = node
     ///         .as_node()?
-    ///         .as_tree_node()?
-    ///         .data
     ///         .as_element_node()?;
     ///
     ///     assert_eq!(element.name, "div");
@@ -120,11 +115,8 @@ impl Xpath {
         &self,
         item_tree: &'tree XpathItemTree,
     ) -> Result<XpathItemSet<'tree>, ExpressionApplyError> {
-        let context = XpathExpressionContext::new_single(
-            item_tree,
-            XpathItem::Node(Node::TreeNode(item_tree.root())),
-            true,
-        );
+        let context =
+            XpathExpressionContext::new_single(item_tree, XpathItem::Node(item_tree.root()), true);
         let mut item_set = self.eval(&context)?;
         item_set.sort();
         Ok(item_set)
@@ -146,7 +138,7 @@ impl Xpath {
     ///
     /// ```rust
     /// use skyscraper::html::{self, trim_internal_whitespace};
-    /// use skyscraper::xpath::{self, XpathItemTree, grammar::{XpathItemTreeNodeData, data_model::{Node, XpathItem}}};
+    /// use skyscraper::xpath::{self, XpathItemTree, grammar::{XpathItemTreeNodeData, data_model::{XpathItem}}};
     /// use std::error::Error;
     ///
     /// fn main() -> Result<(), Box<dyn Error>> {
@@ -172,11 +164,9 @@ impl Xpath {
     ///
     ///     let item = items.next().unwrap();
     ///     let tree_node = item
-    ///         .as_node()?
-    ///         .as_tree_node()?;
+    ///         .as_node()?;
     ///
     ///     let element = tree_node
-    ///         .data
     ///         .as_element_node()?;
     ///
     ///     assert_eq!(element.name, "span");

--- a/src/xpath/grammar/expressions/mod.rs
+++ b/src/xpath/grammar/expressions/mod.rs
@@ -78,7 +78,7 @@ impl Xpath {
     ///
     /// ```rust
     /// use skyscraper::html;
-    /// use skyscraper::xpath::{self, XpathItemTree, grammar::{XpathItemTreeNodeData, data_model::XpathItem}};
+    /// use skyscraper::xpath::{self, XpathItemTree, grammar::{XpathItemTreeNode, data_model::XpathItem}};
     /// use std::error::Error;
     ///
     /// fn main() -> Result<(), Box<dyn Error>> {
@@ -138,7 +138,7 @@ impl Xpath {
     ///
     /// ```rust
     /// use skyscraper::html::{self, trim_internal_whitespace};
-    /// use skyscraper::xpath::{self, XpathItemTree, grammar::{XpathItemTreeNodeData, data_model::{XpathItem}}};
+    /// use skyscraper::xpath::{self, XpathItemTree, grammar::{XpathItemTreeNode, data_model::{XpathItem}}};
     /// use std::error::Error;
     ///
     /// fn main() -> Result<(), Box<dyn Error>> {

--- a/src/xpath/grammar/expressions/path_expressions/steps/axis_step.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/axis_step.rs
@@ -15,7 +15,7 @@ use crate::xpath::{
             postfix_expressions::Predicate,
         },
         recipes::Res,
-        XpathItemTreeNodeData,
+        XpathItemTreeNode,
     },
     ExpressionApplyError, XpathExpressionContext, XpathItemSet,
 };
@@ -115,7 +115,7 @@ impl AxisStepType {
     pub(crate) fn eval<'tree>(
         &self,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
         match self {
             AxisStepType::ReverseStep(step) => step.eval(context),
             AxisStepType::ForwardStep(step) => step.eval(context),

--- a/src/xpath/grammar/expressions/path_expressions/steps/axis_step.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/axis_step.rs
@@ -5,7 +5,7 @@ use nom::{branch::alt, error::context, sequence::tuple};
 
 use crate::xpath::{
     grammar::{
-        data_model::{Node, XpathItem},
+        data_model::XpathItem,
         expressions::{
             path_expressions::steps::{
                 forward_step::forward_step,
@@ -15,6 +15,7 @@ use crate::xpath::{
             postfix_expressions::Predicate,
         },
         recipes::Res,
+        XpathItemTreeNodeData,
     },
     ExpressionApplyError, XpathExpressionContext, XpathItemSet,
 };
@@ -114,7 +115,7 @@ impl AxisStepType {
     pub(crate) fn eval<'tree>(
         &self,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<IndexSet<Node<'tree>>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
         match self {
             AxisStepType::ReverseStep(step) => step.eval(context),
             AxisStepType::ForwardStep(step) => step.eval(context),

--- a/src/xpath/grammar/expressions/path_expressions/steps/forward_step.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/forward_step.rs
@@ -12,7 +12,7 @@ use crate::xpath::{
         },
         recipes::Res,
         whitespace_recipes::ws,
-        XpathItemTreeNodeData,
+        XpathItemTreeNode,
     },
     xpath_item_set::XpathItemSet,
     ExpressionApplyError, XpathExpressionContext,
@@ -61,7 +61,7 @@ impl ForwardStep {
     pub(crate) fn eval<'tree>(
         &self,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
         match self {
             ForwardStep::Full(axis, node_test) => eval_forward_axis(context, *axis, node_test),
             ForwardStep::Abbreviated(step) => {
@@ -82,7 +82,7 @@ fn eval_forward_axis<'tree>(
     context: &XpathExpressionContext<'tree>,
     axis: ForwardAxis,
     node_test: &NodeTest,
-) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
     let axis_nodes = match axis {
         ForwardAxis::Child => eval_forward_axis_child(context),
         ForwardAxis::Descendant => eval_forward_axis_descendant(context),
@@ -114,8 +114,8 @@ fn eval_forward_axis<'tree>(
 /// Direct children of the context nodes.
 fn eval_forward_axis_child<'tree>(
     context: &XpathExpressionContext<'tree>,
-) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
-    let mut nodes: IndexSet<&'tree XpathItemTreeNodeData> = IndexSet::new();
+) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
+    let mut nodes: IndexSet<&'tree XpathItemTreeNode> = IndexSet::new();
 
     // Only tree nodes have children
     if let XpathItem::Node(node) = &context.item {
@@ -130,8 +130,8 @@ fn eval_forward_axis_child<'tree>(
 /// All descendants of the context nodes.
 fn eval_forward_axis_descendant<'tree>(
     context: &XpathExpressionContext<'tree>,
-) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
-    let mut nodes: IndexSet<&'tree XpathItemTreeNodeData> = IndexSet::new();
+) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
+    let mut nodes: IndexSet<&'tree XpathItemTreeNode> = IndexSet::new();
 
     // Only tree nodes have children.
     if let XpathItem::Node(node) = &context.item {
@@ -156,7 +156,7 @@ fn eval_forward_axis_descendant<'tree>(
 /// All descendants of the context nodes including the context nodes.
 fn eval_forward_axis_self_or_descendant<'tree>(
     context: &XpathExpressionContext<'tree>,
-) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
     let mut nodes = IndexSet::new();
 
     if let XpathItem::Node(node) = &context.item {
@@ -175,14 +175,14 @@ fn eval_forward_axis_self_or_descendant<'tree>(
 // All attributes of the context nodes.
 fn eval_forward_axis_attribute<'tree>(
     context: &XpathExpressionContext<'tree>,
-) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
-    let mut attributes: IndexSet<&'tree XpathItemTreeNodeData> = IndexSet::new();
+) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
+    let mut attributes: IndexSet<&'tree XpathItemTreeNode> = IndexSet::new();
 
     // Only elements have attributes.
-    if let XpathItem::Node(XpathItemTreeNodeData::ElementNode(element)) = context.item {
+    if let XpathItem::Node(XpathItemTreeNode::ElementNode(element)) = context.item {
         let element_tree_node = context.item_tree.get(element.id());
         for child in element_tree_node.children(context.item_tree) {
-            if let XpathItemTreeNodeData::AttributeNode(_attribute) = &child {
+            if let XpathItemTreeNode::AttributeNode(_attribute) = &child {
                 attributes.insert(child);
             }
         }

--- a/src/xpath/grammar/expressions/path_expressions/steps/forward_step.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/forward_step.rs
@@ -160,7 +160,7 @@ fn eval_forward_axis_self_or_descendant<'tree>(
     let mut nodes = IndexSet::new();
 
     if let XpathItem::Node(node) = &context.item {
-        nodes.insert(node.clone());
+        nodes.insert(*node);
     } else {
         return Err(ExpressionApplyError {
             msg: String::from("err:XPTY0020 context item for axis step is not a node"),

--- a/src/xpath/grammar/expressions/path_expressions/steps/node_tests.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/node_tests.rs
@@ -9,12 +9,12 @@ use nom::{
 use crate::{
     xpath::{
         grammar::{
-            data_model::{Node, XpathItem},
+            data_model::XpathItem,
             recipes::Res,
             terminal_symbols::braced_uri_literal,
             types::{eq_name, kind_test, EQName, KindTest},
             xml_names::{nc_name, QName},
-            NonTreeXpathNode, XpathItemTreeNode, XpathItemTreeNodeData,
+            XpathItemTreeNode, XpathItemTreeNodeData,
         },
         ExpressionApplyError, XpathExpressionContext,
     },
@@ -57,13 +57,13 @@ impl NodeTest {
         &self,
         axis: BiDirectionalAxis,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<Option<Node<'tree>>, ExpressionApplyError> {
+    ) -> Result<Option<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
         match self {
             NodeTest::KindTest(test) => {
                 let filtered_nodes = test.filter(&xpath_item_set![context.item.clone()])?;
 
                 if !filtered_nodes.is_empty() {
-                    let node: Node<'_> = filtered_nodes.into_iter().next().unwrap();
+                    let node: XpathItemTreeNode<'_> = filtered_nodes.into_iter().next().unwrap();
                     Ok(Some(node))
                 } else {
                     Ok(None)
@@ -113,7 +113,7 @@ impl NameTest {
         &self,
         axis: BiDirectionalAxis,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<Option<Node<'tree>>, ExpressionApplyError> {
+    ) -> Result<Option<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
         let node = if let XpathItem::Node(node) = &context.item {
             node
         } else {
@@ -123,18 +123,13 @@ impl NameTest {
         let is_match = match self {
             NameTest::Name(expected_name) => {
                 // Get the name of the node, if available for the node type.
-                let node_name = match node {
-                    Node::TreeNode(tree_node) => match tree_node.data {
-                        XpathItemTreeNodeData::DocumentNode(_) => todo!(),
-                        XpathItemTreeNodeData::ElementNode(e) => Some(&e.name),
-                        XpathItemTreeNodeData::PINode(_) => todo!(),
-                        XpathItemTreeNodeData::CommentNode(_) => todo!(),
-                        XpathItemTreeNodeData::TextNode(_) => None, // Text nodes do not have a name.
-                    },
-                    Node::NonTreeNode(non_tree_node) => match non_tree_node {
-                        NonTreeXpathNode::AttributeNode(a) => Some(&a.name),
-                        NonTreeXpathNode::NamespaceNode(_) => todo!(),
-                    },
+                let node_name = match node.data {
+                    XpathItemTreeNodeData::DocumentNode(_) => todo!(),
+                    XpathItemTreeNodeData::ElementNode(e) => Some(&e.name),
+                    XpathItemTreeNodeData::PINode(_) => todo!(),
+                    XpathItemTreeNodeData::CommentNode(_) => todo!(),
+                    XpathItemTreeNodeData::TextNode(_) => None, // Text nodes do not have a name.
+                    XpathItemTreeNodeData::AttributeNode(a) => Some(&a.name),
                 };
 
                 match node_name {
@@ -216,26 +211,26 @@ impl Display for Wildcard {
 }
 
 impl Wildcard {
-    pub(crate) fn is_match<'tree>(&self, axis: BiDirectionalAxis, node: &Node<'tree>) -> bool {
+    pub(crate) fn is_match<'tree>(
+        &self,
+        axis: BiDirectionalAxis,
+        node: &XpathItemTreeNode<'tree>,
+    ) -> bool {
         // Wildcards only match context items that are the axis' principal node kind.
         // https://www.w3.org/TR/2017/REC-xpath-31-20170321/#dt-principal-node-kind
         let is_principal_node_kind = match axis {
             BiDirectionalAxis::ForwardAxis(ForwardAxis::Attribute) => {
                 // For the attribute axis, the principal node kind is attribute.
-                matches!(node, Node::NonTreeNode(NonTreeXpathNode::AttributeNode(_)))
-            }
-            BiDirectionalAxis::ForwardAxis(ForwardAxis::Namespace) => {
-                // For the namespace axis, the principal node kind is namespace.
-                matches!(node, Node::NonTreeNode(NonTreeXpathNode::NamespaceNode(_)))
+                matches!(node.data, XpathItemTreeNodeData::AttributeNode(_))
             }
             _ => {
                 // For all other axes, the principal node kind is element.
                 matches!(
                     node,
-                    Node::TreeNode(XpathItemTreeNode {
+                    XpathItemTreeNode {
                         data: XpathItemTreeNodeData::ElementNode(_),
                         ..
-                    })
+                    }
                 )
             }
         };

--- a/src/xpath/grammar/expressions/path_expressions/steps/node_tests.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/node_tests.rs
@@ -14,7 +14,7 @@ use crate::{
             terminal_symbols::braced_uri_literal,
             types::{eq_name, kind_test, EQName, KindTest},
             xml_names::{nc_name, QName},
-            XpathItemTreeNodeData,
+            XpathItemTreeNode,
         },
         ExpressionApplyError, XpathExpressionContext,
     },
@@ -57,13 +57,13 @@ impl NodeTest {
         &self,
         axis: BiDirectionalAxis,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<Option<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    ) -> Result<Option<&'tree XpathItemTreeNode>, ExpressionApplyError> {
         match self {
             NodeTest::KindTest(test) => {
                 let filtered_nodes = test.filter(&xpath_item_set![context.item.clone()])?;
 
                 if !filtered_nodes.is_empty() {
-                    let node: &'tree XpathItemTreeNodeData =
+                    let node: &'tree XpathItemTreeNode =
                         filtered_nodes.into_iter().next().unwrap();
                     Ok(Some(node))
                 } else {
@@ -114,7 +114,7 @@ impl NameTest {
         &self,
         axis: BiDirectionalAxis,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<Option<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    ) -> Result<Option<&'tree XpathItemTreeNode>, ExpressionApplyError> {
         let node = if let XpathItem::Node(node) = &context.item {
             node
         } else {
@@ -125,12 +125,12 @@ impl NameTest {
             NameTest::Name(expected_name) => {
                 // Get the name of the node, if available for the node type.
                 let node_name = match node {
-                    XpathItemTreeNodeData::DocumentNode(_) => todo!(),
-                    XpathItemTreeNodeData::ElementNode(e) => Some(&e.name),
-                    XpathItemTreeNodeData::PINode(_) => todo!(),
-                    XpathItemTreeNodeData::CommentNode(_) => todo!(),
-                    XpathItemTreeNodeData::TextNode(_) => None, // Text nodes do not have a name.
-                    XpathItemTreeNodeData::AttributeNode(a) => Some(&a.name),
+                    XpathItemTreeNode::DocumentNode(_) => todo!(),
+                    XpathItemTreeNode::ElementNode(e) => Some(&e.name),
+                    XpathItemTreeNode::PINode(_) => todo!(),
+                    XpathItemTreeNode::CommentNode(_) => todo!(),
+                    XpathItemTreeNode::TextNode(_) => None, // Text nodes do not have a name.
+                    XpathItemTreeNode::AttributeNode(a) => Some(&a.name),
                 };
 
                 match node_name {
@@ -215,18 +215,18 @@ impl Wildcard {
     pub(crate) fn is_match<'tree>(
         &self,
         axis: BiDirectionalAxis,
-        node: &'tree XpathItemTreeNodeData,
+        node: &'tree XpathItemTreeNode,
     ) -> bool {
         // Wildcards only match context items that are the axis' principal node kind.
         // https://www.w3.org/TR/2017/REC-xpath-31-20170321/#dt-principal-node-kind
         let is_principal_node_kind = match axis {
             BiDirectionalAxis::ForwardAxis(ForwardAxis::Attribute) => {
                 // For the attribute axis, the principal node kind is attribute.
-                matches!(node, XpathItemTreeNodeData::AttributeNode(_))
+                matches!(node, XpathItemTreeNode::AttributeNode(_))
             }
             _ => {
                 // For all other axes, the principal node kind is element.
-                matches!(node, XpathItemTreeNodeData::ElementNode(_),)
+                matches!(node, XpathItemTreeNode::ElementNode(_),)
             }
         };
 

--- a/src/xpath/grammar/expressions/path_expressions/steps/node_tests.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/node_tests.rs
@@ -151,7 +151,7 @@ impl NameTest {
         };
 
         if is_match {
-            Ok(Some(node.clone()))
+            Ok(Some(*node))
         } else {
             Ok(None)
         }

--- a/src/xpath/grammar/expressions/path_expressions/steps/reverse_step.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/reverse_step.rs
@@ -12,7 +12,7 @@ use crate::xpath::{
         recipes::Res,
         types::KindTest,
         whitespace_recipes::ws,
-        XpathItemTreeNode,
+        XpathItemTreeNodeData,
     },
     xpath_item_set::XpathItemSet,
     ExpressionApplyError, XpathExpressionContext,
@@ -60,7 +60,7 @@ impl ReverseStep {
     pub(crate) fn eval<'tree>(
         &self,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
         match self {
             ReverseStep::Full(axis, node_test) => eval_reverse_axis(context, *axis, node_test),
             ReverseStep::Abbreviated => {
@@ -79,8 +79,8 @@ fn eval_reverse_axis<'tree>(
     context: &XpathExpressionContext<'tree>,
     axis: ReverseAxis,
     node_test: &NodeTest,
-) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
-    let axis_nodes: IndexSet<XpathItemTreeNode> = match axis {
+) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    let axis_nodes: IndexSet<&'tree XpathItemTreeNodeData> = match axis {
         ReverseAxis::Parent => eval_reverse_axis_parent(context),
         ReverseAxis::Ancestor => todo!("eval_reverse_axis ReverseAxis::Ancestor"),
         ReverseAxis::PrecedingSibling => todo!("eval_reverse_axis ReverseAxis::PrecedingSibling"),
@@ -108,8 +108,8 @@ fn eval_reverse_axis<'tree>(
 /// Direct parent of the context node.
 fn eval_reverse_axis_parent<'tree>(
     context: &XpathExpressionContext<'tree>,
-) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
-    let mut nodes: IndexSet<XpathItemTreeNode<'tree>> = IndexSet::new();
+) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    let mut nodes: IndexSet<&'tree XpathItemTreeNodeData> = IndexSet::new();
 
     // Only tree items have parents
     // TODO: Technically an attribute's parent is an element, but there is no link to that ATM.

--- a/src/xpath/grammar/expressions/path_expressions/steps/reverse_step.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/reverse_step.rs
@@ -115,7 +115,7 @@ fn eval_reverse_axis_parent<'tree>(
     // TODO: Technically an attribute's parent is an element, but there is no link to that ATM.
     if let XpathItem::Node(node) = &context.item {
         if let Some(parent) = &node.parent(context.item_tree) {
-            nodes.insert(parent.clone());
+            nodes.insert(*parent);
         }
     }
 

--- a/src/xpath/grammar/expressions/path_expressions/steps/reverse_step.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/reverse_step.rs
@@ -5,13 +5,14 @@ use nom::{branch::alt, bytes::complete::tag, error::context};
 
 use crate::xpath::{
     grammar::{
-        data_model::{Node, XpathItem},
+        data_model::XpathItem,
         expressions::path_expressions::steps::{
             axes::reverse_axis::reverse_axis, node_tests::node_test,
         },
         recipes::Res,
         types::KindTest,
         whitespace_recipes::ws,
+        XpathItemTreeNode,
     },
     xpath_item_set::XpathItemSet,
     ExpressionApplyError, XpathExpressionContext,
@@ -59,7 +60,7 @@ impl ReverseStep {
     pub(crate) fn eval<'tree>(
         &self,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<IndexSet<Node<'tree>>, ExpressionApplyError> {
+    ) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
         match self {
             ReverseStep::Full(axis, node_test) => eval_reverse_axis(context, *axis, node_test),
             ReverseStep::Abbreviated => {
@@ -78,8 +79,8 @@ fn eval_reverse_axis<'tree>(
     context: &XpathExpressionContext<'tree>,
     axis: ReverseAxis,
     node_test: &NodeTest,
-) -> Result<IndexSet<Node<'tree>>, ExpressionApplyError> {
-    let axis_nodes: IndexSet<Node> = match axis {
+) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
+    let axis_nodes: IndexSet<XpathItemTreeNode> = match axis {
         ReverseAxis::Parent => eval_reverse_axis_parent(context),
         ReverseAxis::Ancestor => todo!("eval_reverse_axis ReverseAxis::Ancestor"),
         ReverseAxis::PrecedingSibling => todo!("eval_reverse_axis ReverseAxis::PrecedingSibling"),
@@ -107,14 +108,14 @@ fn eval_reverse_axis<'tree>(
 /// Direct parent of the context node.
 fn eval_reverse_axis_parent<'tree>(
     context: &XpathExpressionContext<'tree>,
-) -> Result<IndexSet<Node<'tree>>, ExpressionApplyError> {
-    let mut nodes: IndexSet<Node<'tree>> = IndexSet::new();
+) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
+    let mut nodes: IndexSet<XpathItemTreeNode<'tree>> = IndexSet::new();
 
     // Only tree items have parents
     // TODO: Technically an attribute's parent is an element, but there is no link to that ATM.
-    if let XpathItem::Node(Node::TreeNode(node)) = &context.item {
+    if let XpathItem::Node(node) = &context.item {
         if let Some(parent) = &node.parent(context.item_tree) {
-            nodes.insert(Node::TreeNode(parent.clone()));
+            nodes.insert(parent.clone());
         }
     }
 

--- a/src/xpath/grammar/expressions/path_expressions/steps/reverse_step.rs
+++ b/src/xpath/grammar/expressions/path_expressions/steps/reverse_step.rs
@@ -12,7 +12,7 @@ use crate::xpath::{
         recipes::Res,
         types::KindTest,
         whitespace_recipes::ws,
-        XpathItemTreeNodeData,
+        XpathItemTreeNode,
     },
     xpath_item_set::XpathItemSet,
     ExpressionApplyError, XpathExpressionContext,
@@ -60,7 +60,7 @@ impl ReverseStep {
     pub(crate) fn eval<'tree>(
         &self,
         context: &XpathExpressionContext<'tree>,
-    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
         match self {
             ReverseStep::Full(axis, node_test) => eval_reverse_axis(context, *axis, node_test),
             ReverseStep::Abbreviated => {
@@ -79,8 +79,8 @@ fn eval_reverse_axis<'tree>(
     context: &XpathExpressionContext<'tree>,
     axis: ReverseAxis,
     node_test: &NodeTest,
-) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
-    let axis_nodes: IndexSet<&'tree XpathItemTreeNodeData> = match axis {
+) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
+    let axis_nodes: IndexSet<&'tree XpathItemTreeNode> = match axis {
         ReverseAxis::Parent => eval_reverse_axis_parent(context),
         ReverseAxis::Ancestor => todo!("eval_reverse_axis ReverseAxis::Ancestor"),
         ReverseAxis::PrecedingSibling => todo!("eval_reverse_axis ReverseAxis::PrecedingSibling"),
@@ -108,8 +108,8 @@ fn eval_reverse_axis<'tree>(
 /// Direct parent of the context node.
 fn eval_reverse_axis_parent<'tree>(
     context: &XpathExpressionContext<'tree>,
-) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
-    let mut nodes: IndexSet<&'tree XpathItemTreeNodeData> = IndexSet::new();
+) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
+    let mut nodes: IndexSet<&'tree XpathItemTreeNode> = IndexSet::new();
 
     // Only tree items have parents
     // TODO: Technically an attribute's parent is an element, but there is no link to that ATM.

--- a/src/xpath/grammar/expressions/primary_expressions/static_function_calls.rs
+++ b/src/xpath/grammar/expressions/primary_expressions/static_function_calls.rs
@@ -139,10 +139,10 @@ pub(crate) fn func_data<'tree>(
         match item {
             XpathItem::Node(node) => match node {
                 XpathItemTreeNodeData::DocumentNode(_) => {
-                    AnyAtomicType::String(node.all_text(item_tree))
+                    AnyAtomicType::String(node.text_content(item_tree))
                 }
                 XpathItemTreeNodeData::ElementNode(_) => {
-                    AnyAtomicType::String(node.all_text(item_tree))
+                    AnyAtomicType::String(node.text_content(item_tree))
                 }
                 XpathItemTreeNodeData::PINode(_) => todo!("func_data PINode"),
                 XpathItemTreeNodeData::CommentNode(_) => todo!("func_data CommentNode"),
@@ -165,8 +165,8 @@ pub(crate) fn func_data<'tree>(
 pub(crate) fn func_string<'tree>(item: &XpathItem, item_tree: &'tree XpathItemTree) -> String {
     match item {
         XpathItem::Node(node) => match node {
-            XpathItemTreeNodeData::DocumentNode(_) => node.all_text(item_tree),
-            XpathItemTreeNodeData::ElementNode(_) => node.all_text(item_tree),
+            XpathItemTreeNodeData::DocumentNode(_) => node.text_content(item_tree),
+            XpathItemTreeNodeData::ElementNode(_) => node.text_content(item_tree),
             XpathItemTreeNodeData::PINode(_) => todo!("func_string PINode"),
             XpathItemTreeNodeData::CommentNode(_) => todo!("func_string CommentNode"),
             XpathItemTreeNodeData::TextNode(text) => text.content.clone(),

--- a/src/xpath/grammar/expressions/primary_expressions/static_function_calls.rs
+++ b/src/xpath/grammar/expressions/primary_expressions/static_function_calls.rs
@@ -13,7 +13,7 @@ use crate::{
             types::{eq_name, EQName},
             whitespace_recipes::ws,
             xml_names::QName,
-            XpathItemTreeNodeData,
+            XpathItemTreeNode,
         },
         xpath_item_set::XpathItemSet,
         ExpressionApplyError, XpathExpressionContext, XpathItemTree,
@@ -138,18 +138,18 @@ pub(crate) fn func_data<'tree>(
     fn atomize<'tree>(item: &XpathItem, item_tree: &'tree XpathItemTree) -> AnyAtomicType {
         match item {
             XpathItem::Node(node) => match node {
-                XpathItemTreeNodeData::DocumentNode(_) => {
+                XpathItemTreeNode::DocumentNode(_) => {
                     AnyAtomicType::String(node.text_content(item_tree))
                 }
-                XpathItemTreeNodeData::ElementNode(_) => {
+                XpathItemTreeNode::ElementNode(_) => {
                     AnyAtomicType::String(node.text_content(item_tree))
                 }
-                XpathItemTreeNodeData::PINode(_) => todo!("func_data PINode"),
-                XpathItemTreeNodeData::CommentNode(_) => todo!("func_data CommentNode"),
-                XpathItemTreeNodeData::TextNode(text) => {
+                XpathItemTreeNode::PINode(_) => todo!("func_data PINode"),
+                XpathItemTreeNode::CommentNode(_) => todo!("func_data CommentNode"),
+                XpathItemTreeNode::TextNode(text) => {
                     AnyAtomicType::String(text.content.clone())
                 }
-                &XpathItemTreeNodeData::AttributeNode(attribute) => {
+                &XpathItemTreeNode::AttributeNode(attribute) => {
                     AnyAtomicType::String(attribute.value.clone())
                 }
             },
@@ -165,12 +165,12 @@ pub(crate) fn func_data<'tree>(
 pub(crate) fn func_string<'tree>(item: &XpathItem, item_tree: &'tree XpathItemTree) -> String {
     match item {
         XpathItem::Node(node) => match node {
-            XpathItemTreeNodeData::DocumentNode(_) => node.text_content(item_tree),
-            XpathItemTreeNodeData::ElementNode(_) => node.text_content(item_tree),
-            XpathItemTreeNodeData::PINode(_) => todo!("func_string PINode"),
-            XpathItemTreeNodeData::CommentNode(_) => todo!("func_string CommentNode"),
-            XpathItemTreeNodeData::TextNode(text) => text.content.clone(),
-            XpathItemTreeNodeData::AttributeNode(attribute) => attribute.value.clone(),
+            XpathItemTreeNode::DocumentNode(_) => node.text_content(item_tree),
+            XpathItemTreeNode::ElementNode(_) => node.text_content(item_tree),
+            XpathItemTreeNode::PINode(_) => todo!("func_string PINode"),
+            XpathItemTreeNode::CommentNode(_) => todo!("func_string CommentNode"),
+            XpathItemTreeNode::TextNode(text) => text.content.clone(),
+            XpathItemTreeNode::AttributeNode(attribute) => attribute.value.clone(),
         },
         XpathItem::AnyAtomicType(atomic) => match atomic {
             AnyAtomicType::Boolean(b) => b.to_string(),

--- a/src/xpath/grammar/expressions/primary_expressions/static_function_calls.rs
+++ b/src/xpath/grammar/expressions/primary_expressions/static_function_calls.rs
@@ -137,7 +137,7 @@ pub(crate) fn func_data<'tree>(
 ) -> Vec<AnyAtomicType> {
     fn atomize<'tree>(item: &XpathItem, item_tree: &'tree XpathItemTree) -> AnyAtomicType {
         match item {
-            XpathItem::Node(node) => match node.data {
+            XpathItem::Node(node) => match node {
                 XpathItemTreeNodeData::DocumentNode(_) => {
                     AnyAtomicType::String(node.all_text(item_tree))
                 }
@@ -162,12 +162,9 @@ pub(crate) fn func_data<'tree>(
 }
 
 /// https://www.w3.org/TR/xpath-functions-31/#func-string
-pub(crate) fn func_string<'tree>(
-    item: &XpathItem<'tree>,
-    item_tree: &'tree XpathItemTree,
-) -> String {
+pub(crate) fn func_string<'tree>(item: &XpathItem, item_tree: &'tree XpathItemTree) -> String {
     match item {
-        XpathItem::Node(node) => match node.data {
+        XpathItem::Node(node) => match node {
             XpathItemTreeNodeData::DocumentNode(_) => node.all_text(item_tree),
             XpathItemTreeNodeData::ElementNode(_) => node.all_text(item_tree),
             XpathItemTreeNodeData::PINode(_) => todo!("func_string PINode"),

--- a/src/xpath/grammar/expressions/primary_expressions/static_function_calls.rs
+++ b/src/xpath/grammar/expressions/primary_expressions/static_function_calls.rs
@@ -7,13 +7,13 @@ use nom::error::context;
 use crate::{
     xpath::{
         grammar::{
-            data_model::{AnyAtomicType, Node, XpathItem},
+            data_model::{AnyAtomicType, XpathItem},
             expressions::common::{argument_list, ArgumentList},
             recipes::Res,
             types::{eq_name, EQName},
             whitespace_recipes::ws,
             xml_names::QName,
-            NonTreeXpathNode, XpathItemTreeNodeData,
+            XpathItemTreeNodeData,
         },
         xpath_item_set::XpathItemSet,
         ExpressionApplyError, XpathExpressionContext, XpathItemTree,
@@ -58,9 +58,7 @@ impl FunctionCall {
                     if prefixed_name.prefix == "fn" {
                         // Root function selects the root node of the tree.
                         if prefixed_name.local_part == "root" {
-                            return Ok(xpath_item_set![XpathItem::Node(Node::TreeNode(
-                                context.item_tree.root(),
-                            ))]);
+                            return Ok(xpath_item_set![XpathItem::Node(context.item_tree.root())]);
                         }
                     }
 
@@ -139,26 +137,21 @@ pub(crate) fn func_data<'tree>(
 ) -> Vec<AnyAtomicType> {
     fn atomize<'tree>(item: &XpathItem, item_tree: &'tree XpathItemTree) -> AnyAtomicType {
         match item {
-            XpathItem::Node(node) => match node {
-                Node::TreeNode(tree_node) => match tree_node.data {
-                    XpathItemTreeNodeData::DocumentNode(_) => {
-                        AnyAtomicType::String(tree_node.all_text(item_tree))
-                    }
-                    XpathItemTreeNodeData::ElementNode(_) => {
-                        AnyAtomicType::String(tree_node.all_text(item_tree))
-                    }
-                    XpathItemTreeNodeData::PINode(_) => todo!("func_data PINode"),
-                    XpathItemTreeNodeData::CommentNode(_) => todo!("func_data CommentNode"),
-                    XpathItemTreeNodeData::TextNode(text) => {
-                        AnyAtomicType::String(text.content.clone())
-                    }
-                },
-                Node::NonTreeNode(non_tree_node) => match non_tree_node {
-                    NonTreeXpathNode::AttributeNode(attribute) => {
-                        AnyAtomicType::String(attribute.value.clone())
-                    }
-                    NonTreeXpathNode::NamespaceNode(_) => todo!("func_data NamespaceNode"),
-                },
+            XpathItem::Node(node) => match node.data {
+                XpathItemTreeNodeData::DocumentNode(_) => {
+                    AnyAtomicType::String(node.all_text(item_tree))
+                }
+                XpathItemTreeNodeData::ElementNode(_) => {
+                    AnyAtomicType::String(node.all_text(item_tree))
+                }
+                XpathItemTreeNodeData::PINode(_) => todo!("func_data PINode"),
+                XpathItemTreeNodeData::CommentNode(_) => todo!("func_data CommentNode"),
+                XpathItemTreeNodeData::TextNode(text) => {
+                    AnyAtomicType::String(text.content.clone())
+                }
+                &XpathItemTreeNodeData::AttributeNode(attribute) => {
+                    AnyAtomicType::String(attribute.value.clone())
+                }
             },
             XpathItem::Function(_) => todo!("func_data Function"),
             XpathItem::AnyAtomicType(atomic) => atomic.clone(),
@@ -174,18 +167,13 @@ pub(crate) fn func_string<'tree>(
     item_tree: &'tree XpathItemTree,
 ) -> String {
     match item {
-        XpathItem::Node(node) => match node {
-            Node::TreeNode(tree_node) => match tree_node.data {
-                XpathItemTreeNodeData::DocumentNode(_) => tree_node.all_text(item_tree),
-                XpathItemTreeNodeData::ElementNode(_) => tree_node.all_text(item_tree),
-                XpathItemTreeNodeData::PINode(_) => todo!("func_string PINode"),
-                XpathItemTreeNodeData::CommentNode(_) => todo!("func_string CommentNode"),
-                XpathItemTreeNodeData::TextNode(text) => text.content.clone(),
-            },
-            Node::NonTreeNode(non_tree_node) => match non_tree_node {
-                NonTreeXpathNode::AttributeNode(attribute) => attribute.value.clone(),
-                NonTreeXpathNode::NamespaceNode(_) => todo!("func_string NamespaceNode"),
-            },
+        XpathItem::Node(node) => match node.data {
+            XpathItemTreeNodeData::DocumentNode(_) => node.all_text(item_tree),
+            XpathItemTreeNodeData::ElementNode(_) => node.all_text(item_tree),
+            XpathItemTreeNodeData::PINode(_) => todo!("func_string PINode"),
+            XpathItemTreeNodeData::CommentNode(_) => todo!("func_string CommentNode"),
+            XpathItemTreeNodeData::TextNode(text) => text.content.clone(),
+            XpathItemTreeNodeData::AttributeNode(attribute) => attribute.value.clone(),
         },
         XpathItem::AnyAtomicType(atomic) => match atomic {
             AnyAtomicType::Boolean(b) => b.to_string(),

--- a/src/xpath/grammar/mod.rs
+++ b/src/xpath/grammar/mod.rs
@@ -12,8 +12,6 @@ mod types;
 mod whitespace_recipes;
 mod xml_names;
 
-use std::{fmt::Display, iter};
-
 use enum_extract_macro::EnumExtract;
 pub(crate) use expressions::xpath;
 pub use expressions::Xpath;
@@ -28,7 +26,7 @@ use crate::{
 };
 
 /// Nodes that are part of the [`XpathItemTree`].
-#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Hash, EnumExtract)]
+#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Hash, EnumExtract, Clone)]
 pub enum XpathItemTreeNodeData {
     /// The root node of the document.
     DocumentNode(XpathDocumentNode),
@@ -51,191 +49,55 @@ pub enum XpathItemTreeNodeData {
     AttributeNode(AttributeNode),
 }
 
-/// A node in the [`XpathItemTree`].
-///
-///  https://www.w3.org/TR/xpath-datamodel-31/#dt-node
-#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Clone, Hash)]
-pub struct XpathItemTreeNode<'a> {
-    id: NodeId,
-
-    /// The data associated with this node.
-    pub data: &'a XpathItemTreeNodeData,
-}
-
-impl Display for XpathItemTreeNode<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.data {
-            XpathItemTreeNodeData::DocumentNode(node) => write!(f, "{}", node),
-            XpathItemTreeNodeData::ElementNode(node) => write!(f, "{}", node),
-            XpathItemTreeNodeData::PINode(node) => write!(f, "{}", node),
-            XpathItemTreeNodeData::CommentNode(node) => write!(f, "{}", node),
-            XpathItemTreeNodeData::TextNode(node) => write!(f, "{}", node),
-            XpathItemTreeNodeData::AttributeNode(node) => write!(f, "{}", node),
+impl XpathItemTreeNodeData {
+    pub fn children<'tree>(&self, tree: &'tree XpathItemTree) -> Vec<&'tree XpathItemTreeNodeData> {
+        match self {
+            XpathItemTreeNodeData::DocumentNode(node) => node.children(tree),
+            XpathItemTreeNodeData::ElementNode(node) => node.children(tree).collect(),
+            XpathItemTreeNodeData::PINode(_) => vec![],
+            XpathItemTreeNodeData::CommentNode(_) => vec![],
+            XpathItemTreeNodeData::TextNode(_) => vec![],
+            XpathItemTreeNodeData::AttributeNode(_) => vec![],
         }
     }
-}
 
-impl<'a> XpathItemTreeNode<'a> {
-    /// Get all the child nodes of this node.
-    ///
-    /// # Arguments
-    ///
-    /// * `tree` - The tree that this node is a part of.
-    ///
-    /// # Returns
-    ///
-    /// An iterator over the child nodes of this node.
-    pub fn children(&self, tree: &'a XpathItemTree) -> impl Iterator<Item = XpathItemTreeNode<'a>> {
-        self.id
-            .children(&tree.arena)
-            .into_iter()
-            .map(move |id| tree.get(id))
+    pub fn parent<'tree>(
+        &self,
+        tree: &'tree XpathItemTree,
+    ) -> Option<&'tree XpathItemTreeNodeData> {
+        let id = match self {
+            XpathItemTreeNodeData::ElementNode(e) => Some(e.id()),
+            XpathItemTreeNodeData::TextNode(t) => Some(t.id()),
+            XpathItemTreeNodeData::AttributeNode(a) => Some(a.id()),
+            _ => None,
+        };
+
+        id.and_then(|id| {
+            let parent_id = tree.arena.get(id).unwrap().parent()?;
+            Some(tree.get(parent_id))
+        })
     }
 
-    /// Get the parent node of this node.
-    ///
-    /// # Arguments
-    ///
-    /// * `tree` - The tree that this node is a part of.
-    ///
-    /// # Returns
-    ///
-    /// The parent node of this node, or `None` if this node is the root node.
-    pub fn parent(&self, tree: &'a XpathItemTree) -> Option<XpathItemTreeNode<'a>> {
-        tree.get_index_node(self.id).parent().map(|id| tree.get(id))
-    }
-
-    /// Get all text contained in this node and its descendants.
-    ///
-    /// Use [`XpathItemTreeNode::text`] to get _only_ text contained directly in this node.
-    ///
-    /// # Arguments
-    ///
-    /// * `tree` - The tree that this node is a part of.
-    ///
-    /// # Returns
-    ///
-    /// A string of all text contained in this node and its descendants.
-    pub fn all_text(&self, tree: &'a XpathItemTree) -> String {
-        let strings: Vec<String> =
-            // Get all children.
-            Self::get_all_text_nodes(tree, self, true)
-            .into_iter()
-            .map(|x| x.content)
-            .collect();
-
-        let text = strings.join("");
-        text
-    }
-
-    /// Get text directly contained in this node.
-    ///
-    /// Use [`XpathItemTreeNode::all_text`] to get all text _including_ text in descendant nodes.
-    ///
-    /// # Arguments
-    ///
-    /// * `tree` - The tree that this node is a part of.
-    ///
-    /// # Returns
-    ///
-    /// A string of all text contained in this node.
-    pub fn text(&self, tree: &XpathItemTree) -> Option<String> {
-        let strings: Vec<String> =
-            // Get all children.
-            Self::get_all_text_nodes(tree, self, false)
-            .into_iter()
-            .map(|x| x.content)
-            .collect();
-
-        strings.into_iter().next()
-    }
-
-    fn get_all_text_nodes(
-        tree: &XpathItemTree,
-        node: &XpathItemTreeNode,
-        recurse: bool,
-    ) -> Vec<TextNode> {
-        node
-            // Get all children of the given node.
-            .children(tree)
-            // Combine all the direct and indirect children into a Vec.
-            .fold(Vec::new(), |mut v, child| {
-                // If this child is a text node, push it to the Vec.
-                if let XpathItemTreeNodeData::TextNode(text) = child.data {
-                    v.push(text.clone());
-                }
-                // Otherwise, if this is a recursive search, get all the text nodes descending from this child.
-                else if recurse {
-                    v.extend(Self::get_all_text_nodes(tree, &child, recurse));
-                }
-                v
-            })
-    }
-
-    /// Get an iterator over all text contained in this node and its descendants.
-    ///
-    /// Includes whitespace text nodes.
-    /// Text nodes are split by opening and closing tags contained in the current node.
-    ///
-    /// ```rust
-    /// use skyscraper::{html, xpath};
-    ///
-    /// let html = r#"
-    ///     <div>
-    ///         <p>Good info</p>
-    ///         Ok info
-    ///         <p>Bad info</p>
-    ///    </div>"#;
-    ///
-    /// let document = html::parse(html).unwrap();
-    /// let xpath_item_tree = xpath::XpathItemTree::from(&document);
-    /// let xpath = xpath::parse("//div").unwrap();
-    ///
-    /// let nodes = xpath.apply(&xpath_item_tree).unwrap();
-    /// let mut nodes = nodes.into_iter();
-    /// let node = nodes.next().unwrap().extract_into_node().extract_into_tree_node();
-    ///
-    /// let text = node.itertext(&xpath_item_tree).collect::<Vec<String>>();
-    ///
-    /// assert_eq!(text, vec![
-    ///     "\n        ",                  // Whitespace between the opening div tag and the first p tag
-    ///     "Good info",                   // Text of the first p tag
-    ///     "\n        Ok info\n        ", // Text between the first and second p tags
-    ///     "Bad info",                    // Text of the second p tag
-    ///     "\n   "                        // Whitespace between the second p tag and the closing div tag
-    /// ]);
-    /// ```
-    pub fn itertext(self, tree: &'a XpathItemTree) -> TextIter<'a> {
-        TextIter::new(tree, self)
-    }
-}
-
-/// An iterator over all text contained in a node and its descendants.
-pub struct TextIter<'a> {
-    iter_chain: Box<dyn Iterator<Item = String> + 'a>,
-}
-
-impl<'a> TextIter<'a> {
-    pub(crate) fn new(tree: &'a XpathItemTree, node: XpathItemTreeNode<'a>) -> TextIter<'a> {
-        let mut iter_chain: Box<dyn Iterator<Item = String>> = Box::new(iter::empty());
-
-        for child in node.children(tree) {
-            if let XpathItemTreeNodeData::TextNode(text) = child.data {
-                iter_chain = Box::new(iter_chain.chain(iter::once(text.content.clone())));
-            } else {
-                iter_chain = Box::new(iter_chain.chain(TextIter::new(tree, child)));
-            }
+    pub fn all_text<'tree>(&self, tree: &'tree XpathItemTree) -> String {
+        match self {
+            XpathItemTreeNodeData::DocumentNode(node) => node.all_text(tree),
+            XpathItemTreeNodeData::ElementNode(node) => node.all_text(tree),
+            XpathItemTreeNodeData::PINode(_) => String::from(""),
+            XpathItemTreeNodeData::CommentNode(_) => String::from(""),
+            XpathItemTreeNodeData::TextNode(node) => node.content.to_string(),
+            XpathItemTreeNodeData::AttributeNode(_) => String::from(""),
         }
-
-        TextIter { iter_chain }
     }
-}
 
-impl<'a> Iterator for TextIter<'a> {
-    type Item = String;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter_chain.next()
+    pub fn text<'tree>(&self, tree: &'tree XpathItemTree) -> Option<String> {
+        match self {
+            XpathItemTreeNodeData::DocumentNode(node) => node.text(tree),
+            XpathItemTreeNodeData::ElementNode(node) => node.text(tree),
+            XpathItemTreeNodeData::PINode(_) => None,
+            XpathItemTreeNodeData::CommentNode(_) => None,
+            XpathItemTreeNodeData::TextNode(node) => None,
+            XpathItemTreeNodeData::AttributeNode(_) => None,
+        }
     }
 }
 
@@ -255,19 +117,18 @@ impl XpathItemTree {
             .expect("xpath item node missing from tree")
     }
 
-    fn get(&self, id: NodeId) -> XpathItemTreeNode<'_> {
+    fn get(&self, id: NodeId) -> &XpathItemTreeNodeData {
         let indextree_node = self.get_index_node(id);
 
-        let data = indextree_node.get();
-        XpathItemTreeNode { id, data }
+        indextree_node.get()
     }
 
-    fn root(&self) -> XpathItemTreeNode<'_> {
+    fn root(&self) -> &XpathItemTreeNodeData {
         self.get(self.root_node)
     }
 
     /// Get an iterator over all nodes in the tree.
-    pub fn iter(&self) -> impl Iterator<Item = XpathItemTreeNode> {
+    pub fn iter(&self) -> impl Iterator<Item = &XpathItemTreeNodeData> {
         self.arena.iter().map(|node| {
             let id = self.arena.get_node_id(node).unwrap();
             self.get(id)
@@ -288,19 +149,8 @@ impl From<&HtmlDocument> for XpathItemTree {
 
             let root_item_id = match html_node {
                 HtmlNode::Tag(tag) => {
-                    let attributes = tag
-                        .attributes
-                        .iter()
-                        .map(|a| AttributeNode {
-                            name: a.0.to_string(),
-                            value: a.1.to_string(),
-                        })
-                        .collect();
-
-                    let node = XpathItemTreeNodeData::ElementNode(ElementNode::new(
-                        tag.name.to_string(),
-                        attributes,
-                    ));
+                    let node =
+                        XpathItemTreeNodeData::ElementNode(ElementNode::new(tag.name.to_string()));
 
                     let item_id = item_arena.new_node(node);
                     item_arena
@@ -310,6 +160,29 @@ impl From<&HtmlDocument> for XpathItemTree {
                         .as_element_node_mut()
                         .unwrap()
                         .set_id(item_id);
+
+                    let attributes: Vec<AttributeNode> = tag
+                        .attributes
+                        .iter()
+                        .map(|(name, value)| {
+                            AttributeNode::new(name.to_string(), value.to_string())
+                        })
+                        .collect();
+
+                    for attribute in attributes {
+                        let attribute_node = XpathItemTreeNodeData::AttributeNode(attribute);
+                        let attribute_id = item_arena.new_node(attribute_node);
+
+                        item_id.append(attribute_id, item_arena);
+
+                        item_arena
+                            .get_mut(attribute_id)
+                            .unwrap()
+                            .get_mut()
+                            .as_attribute_node_mut()
+                            .unwrap()
+                            .set_id(attribute_id);
+                    }
 
                     item_id
                 }

--- a/src/xpath/grammar/mod.rs
+++ b/src/xpath/grammar/mod.rs
@@ -23,28 +23,9 @@ use indextree::{Arena, NodeId};
 use crate::{
     html::{DocumentNode, HtmlDocument, HtmlNode},
     xpath::grammar::data_model::{
-        AttributeNode, CommentNode, ElementNode, NamespaceNode, PINode, TextNode, XpathDocumentNode,
+        AttributeNode, CommentNode, ElementNode, PINode, TextNode, XpathDocumentNode,
     },
 };
-
-/// Nodes that are not part of the [`XpathItemTree`].
-#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Clone, Hash, EnumExtract)]
-pub enum NonTreeXpathNode {
-    /// An attribute node.
-    AttributeNode(AttributeNode),
-
-    /// A namespace node.
-    NamespaceNode(NamespaceNode),
-}
-
-impl Display for NonTreeXpathNode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NonTreeXpathNode::AttributeNode(node) => write!(f, "{}", node),
-            NonTreeXpathNode::NamespaceNode(node) => write!(f, "{}", node),
-        }
-    }
-}
 
 /// Nodes that are part of the [`XpathItemTree`].
 #[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Hash, EnumExtract)]
@@ -65,9 +46,14 @@ pub enum XpathItemTreeNodeData {
 
     /// A text node.
     TextNode(TextNode),
+
+    /// An attribute node.
+    AttributeNode(AttributeNode),
 }
 
 /// A node in the [`XpathItemTree`].
+///
+///  https://www.w3.org/TR/xpath-datamodel-31/#dt-node
 #[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Clone, Hash)]
 pub struct XpathItemTreeNode<'a> {
     id: NodeId,
@@ -84,6 +70,7 @@ impl Display for XpathItemTreeNode<'_> {
             XpathItemTreeNodeData::PINode(node) => write!(f, "{}", node),
             XpathItemTreeNodeData::CommentNode(node) => write!(f, "{}", node),
             XpathItemTreeNodeData::TextNode(node) => write!(f, "{}", node),
+            XpathItemTreeNodeData::AttributeNode(node) => write!(f, "{}", node),
         }
     }
 }

--- a/src/xpath/grammar/mod.rs
+++ b/src/xpath/grammar/mod.rs
@@ -50,6 +50,15 @@ pub enum XpathItemTreeNodeData {
 }
 
 impl XpathItemTreeNodeData {
+    /// Get all children of the document.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - The tree containing the document.
+    ///
+    /// # Returns
+    ///
+    /// A vector of all children of the document.
     pub fn children<'tree>(&self, tree: &'tree XpathItemTree) -> Vec<&'tree XpathItemTreeNodeData> {
         match self {
             XpathItemTreeNodeData::DocumentNode(node) => node.children(tree),
@@ -61,6 +70,15 @@ impl XpathItemTreeNodeData {
         }
     }
 
+    /// Get the parent of the element.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - The tree containing the element.
+    ///
+    /// # Returns
+    ///
+    /// The parent of the element if it exists, or `None` if it does not.
     pub fn parent<'tree>(
         &self,
         tree: &'tree XpathItemTree,
@@ -78,10 +96,19 @@ impl XpathItemTreeNodeData {
         })
     }
 
-    pub fn all_text<'tree>(&self, tree: &'tree XpathItemTree) -> String {
+    /// Get all text contained in this element and its descendants.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - The tree that this element is a part of.
+    ///
+    /// # Returns
+    ///
+    /// A string of all text contained in this element and its descendants.
+    pub fn text_content<'tree>(&self, tree: &'tree XpathItemTree) -> String {
         match self {
-            XpathItemTreeNodeData::DocumentNode(node) => node.all_text(tree),
-            XpathItemTreeNodeData::ElementNode(node) => node.all_text(tree),
+            XpathItemTreeNodeData::DocumentNode(node) => node.text_content(tree),
+            XpathItemTreeNodeData::ElementNode(node) => node.text_content(tree),
             XpathItemTreeNodeData::PINode(_) => String::from(""),
             XpathItemTreeNodeData::CommentNode(_) => String::from(""),
             XpathItemTreeNodeData::TextNode(node) => node.content.to_string(),
@@ -89,13 +116,24 @@ impl XpathItemTreeNodeData {
         }
     }
 
+    /// Text before the first subelement. This is either a string or the value None, if there was no text.
+    ///
+    /// Use [`ElementNode::text_content`] to get all text _including_ text in descendant nodes.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - The tree that this element is a part of.
+    ///
+    /// # Returns
+    ///
+    /// A string of all text contained in this element.
     pub fn text<'tree>(&self, tree: &'tree XpathItemTree) -> Option<String> {
         match self {
             XpathItemTreeNodeData::DocumentNode(node) => node.text(tree),
             XpathItemTreeNodeData::ElementNode(node) => node.text(tree),
             XpathItemTreeNodeData::PINode(_) => None,
             XpathItemTreeNodeData::CommentNode(_) => None,
-            XpathItemTreeNodeData::TextNode(node) => None,
+            XpathItemTreeNodeData::TextNode(node) => Some(node.content.to_string()),
             XpathItemTreeNodeData::AttributeNode(_) => None,
         }
     }

--- a/src/xpath/grammar/types/attribute_test.rs
+++ b/src/xpath/grammar/types/attribute_test.rs
@@ -8,7 +8,7 @@ use nom::{
 
 use crate::xpath::{
     grammar::{
-        recipes::Res, types::common::attribute_name, whitespace_recipes::ws, XpathItemTreeNode,
+        recipes::Res, types::common::attribute_name, whitespace_recipes::ws, XpathItemTreeNodeData,
     },
     ExpressionApplyError,
 };
@@ -60,7 +60,7 @@ impl Display for AttributeTest {
 impl AttributeTest {
     pub(crate) fn is_match<'tree>(
         &self,
-        node: &XpathItemTreeNode<'tree>,
+        node: &'tree XpathItemTreeNodeData,
     ) -> Result<bool, ExpressionApplyError> {
         match &self.pair {
             Some(pair) => pair.is_match(node),
@@ -95,7 +95,7 @@ impl Display for AttributeTestPair {
 impl AttributeTestPair {
     pub(crate) fn is_match<'tree>(
         &self,
-        node: &XpathItemTreeNode<'tree>,
+        node: &'tree XpathItemTreeNodeData,
     ) -> Result<bool, ExpressionApplyError> {
         let is_match = self.name_or_wildcard.is_match(node)?;
 
@@ -143,7 +143,7 @@ impl Display for AttribNameOrWildcard {
 impl AttribNameOrWildcard {
     pub(crate) fn is_match<'tree>(
         &self,
-        _node: &XpathItemTreeNode<'tree>,
+        _node: &'tree XpathItemTreeNodeData,
     ) -> Result<bool, ExpressionApplyError> {
         match self {
             AttribNameOrWildcard::AttributeName(_) => {

--- a/src/xpath/grammar/types/attribute_test.rs
+++ b/src/xpath/grammar/types/attribute_test.rs
@@ -8,7 +8,7 @@ use nom::{
 
 use crate::xpath::{
     grammar::{
-        data_model::Node, recipes::Res, types::common::attribute_name, whitespace_recipes::ws,
+        recipes::Res, types::common::attribute_name, whitespace_recipes::ws, XpathItemTreeNode,
     },
     ExpressionApplyError,
 };
@@ -58,7 +58,10 @@ impl Display for AttributeTest {
 }
 
 impl AttributeTest {
-    pub(crate) fn is_match<'tree>(&self, node: &Node<'tree>) -> Result<bool, ExpressionApplyError> {
+    pub(crate) fn is_match<'tree>(
+        &self,
+        node: &XpathItemTreeNode<'tree>,
+    ) -> Result<bool, ExpressionApplyError> {
         match &self.pair {
             Some(pair) => pair.is_match(node),
             // No value is equivalent to a wildcard.
@@ -90,7 +93,10 @@ impl Display for AttributeTestPair {
 }
 
 impl AttributeTestPair {
-    pub(crate) fn is_match<'tree>(&self, node: &Node<'tree>) -> Result<bool, ExpressionApplyError> {
+    pub(crate) fn is_match<'tree>(
+        &self,
+        node: &XpathItemTreeNode<'tree>,
+    ) -> Result<bool, ExpressionApplyError> {
         let is_match = self.name_or_wildcard.is_match(node)?;
 
         if let Some(_type_name) = &self.type_name {
@@ -137,7 +143,7 @@ impl Display for AttribNameOrWildcard {
 impl AttribNameOrWildcard {
     pub(crate) fn is_match<'tree>(
         &self,
-        _node: &Node<'tree>,
+        _node: &XpathItemTreeNode<'tree>,
     ) -> Result<bool, ExpressionApplyError> {
         match self {
             AttribNameOrWildcard::AttributeName(_) => {

--- a/src/xpath/grammar/types/attribute_test.rs
+++ b/src/xpath/grammar/types/attribute_test.rs
@@ -8,7 +8,7 @@ use nom::{
 
 use crate::xpath::{
     grammar::{
-        recipes::Res, types::common::attribute_name, whitespace_recipes::ws, XpathItemTreeNodeData,
+        recipes::Res, types::common::attribute_name, whitespace_recipes::ws, XpathItemTreeNode,
     },
     ExpressionApplyError,
 };
@@ -60,7 +60,7 @@ impl Display for AttributeTest {
 impl AttributeTest {
     pub(crate) fn is_match<'tree>(
         &self,
-        node: &'tree XpathItemTreeNodeData,
+        node: &'tree XpathItemTreeNode,
     ) -> Result<bool, ExpressionApplyError> {
         match &self.pair {
             Some(pair) => pair.is_match(node),
@@ -95,7 +95,7 @@ impl Display for AttributeTestPair {
 impl AttributeTestPair {
     pub(crate) fn is_match<'tree>(
         &self,
-        node: &'tree XpathItemTreeNodeData,
+        node: &'tree XpathItemTreeNode,
     ) -> Result<bool, ExpressionApplyError> {
         let is_match = self.name_or_wildcard.is_match(node)?;
 
@@ -143,7 +143,7 @@ impl Display for AttribNameOrWildcard {
 impl AttribNameOrWildcard {
     pub(crate) fn is_match<'tree>(
         &self,
-        _node: &'tree XpathItemTreeNodeData,
+        _node: &'tree XpathItemTreeNode,
     ) -> Result<bool, ExpressionApplyError> {
         match self {
             AttribNameOrWildcard::AttributeName(_) => {

--- a/src/xpath/grammar/types/mod.rs
+++ b/src/xpath/grammar/types/mod.rs
@@ -143,7 +143,11 @@ impl KindTest {
                 // Select all node types.
                 let filtered_nodes = item_set.iter().filter_map(|item| {
                     if let XpathItem::Node(node) = item {
-                        Some(node.clone())
+                        if let XpathItemTreeNodeData::AttributeNode(_) = node {
+                            None
+                        } else {
+                            Some(*node)
+                        }
                     } else {
                         None
                     }
@@ -157,7 +161,7 @@ impl KindTest {
                 let filtered_nodes = item_set.iter().filter_map(|item| {
                     if let XpathItem::Node(node) = item {
                         if matches!(node, XpathItemTreeNodeData::TextNode(_),) {
-                            return Some(node.clone());
+                            return Some(*node);
                         }
                     }
 
@@ -175,8 +179,8 @@ impl KindTest {
 
                 for item in item_set {
                     if let XpathItem::Node(node) = item {
-                        if x.is_match(&node)? {
-                            filtered_nodes.insert(node.clone());
+                        if x.is_match(node)? {
+                            filtered_nodes.insert(*node);
                         }
                     }
                 }
@@ -260,7 +264,7 @@ impl DocumentTest {
                 for item in item_set {
                     if let XpathItem::Node(node) = item {
                         if matches!(node, XpathItemTreeNodeData::DocumentNode(_),) {
-                            filtered_nodes.insert(node.clone());
+                            filtered_nodes.insert(*node);
                         }
                     }
                 }

--- a/src/xpath/grammar/types/mod.rs
+++ b/src/xpath/grammar/types/mod.rs
@@ -26,7 +26,7 @@ use self::{
 };
 
 use super::{
-    data_model::{Node, XpathItem},
+    data_model::XpathItem,
     recipes::Res,
     terminal_symbols::UriQualifiedName,
     xml_names::{nc_name, QName},
@@ -136,7 +136,7 @@ impl KindTest {
     pub(crate) fn filter<'tree>(
         &self,
         item_set: &XpathItemSet<'tree>,
-    ) -> Result<IndexSet<Node<'tree>>, ExpressionApplyError> {
+    ) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
         match self {
             KindTest::AnyKindTest => {
                 // AnyKindTest is `node()`.
@@ -158,10 +158,10 @@ impl KindTest {
                     if let XpathItem::Node(node) = item {
                         if matches!(
                             node,
-                            Node::TreeNode(XpathItemTreeNode {
+                            XpathItemTreeNode {
                                 data: XpathItemTreeNodeData::TextNode(_),
                                 ..
-                            })
+                            }
                         ) {
                             return Some(node.clone());
                         }
@@ -257,7 +257,7 @@ impl DocumentTest {
     pub(crate) fn filter<'tree>(
         &self,
         item_set: &XpathItemSet<'tree>,
-    ) -> Result<IndexSet<Node<'tree>>, ExpressionApplyError> {
+    ) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
         match &self.value {
             // document-node() matches any document node.
             None => {
@@ -267,10 +267,10 @@ impl DocumentTest {
                     if let XpathItem::Node(node) = item {
                         if matches!(
                             node,
-                            Node::TreeNode(XpathItemTreeNode {
+                            XpathItemTreeNode {
                                 data: XpathItemTreeNodeData::DocumentNode(_),
                                 ..
-                            })
+                            }
                         ) {
                             filtered_nodes.insert(node.clone());
                         }

--- a/src/xpath/grammar/types/mod.rs
+++ b/src/xpath/grammar/types/mod.rs
@@ -30,7 +30,7 @@ use super::{
     recipes::Res,
     terminal_symbols::UriQualifiedName,
     xml_names::{nc_name, QName},
-    XpathItemTreeNodeData,
+    XpathItemTreeNode,
 };
 
 pub mod array_test;
@@ -136,14 +136,14 @@ impl KindTest {
     pub(crate) fn filter<'tree>(
         &self,
         item_set: &XpathItemSet<'tree>,
-    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
         match self {
             KindTest::AnyKindTest => {
                 // AnyKindTest is `node()`.
                 // Select all node types.
                 let filtered_nodes = item_set.iter().filter_map(|item| {
                     if let XpathItem::Node(node) = item {
-                        if let XpathItemTreeNodeData::AttributeNode(_) = node {
+                        if let XpathItemTreeNode::AttributeNode(_) = node {
                             None
                         } else {
                             Some(*node)
@@ -160,7 +160,7 @@ impl KindTest {
                 // Select all text nodes.
                 let filtered_nodes = item_set.iter().filter_map(|item| {
                     if let XpathItem::Node(node) = item {
-                        if matches!(node, XpathItemTreeNodeData::TextNode(_),) {
+                        if matches!(node, XpathItemTreeNode::TextNode(_),) {
                             return Some(*node);
                         }
                     }
@@ -255,7 +255,7 @@ impl DocumentTest {
     pub(crate) fn filter<'tree>(
         &self,
         item_set: &XpathItemSet<'tree>,
-    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNode>, ExpressionApplyError> {
         match &self.value {
             // document-node() matches any document node.
             None => {
@@ -263,7 +263,7 @@ impl DocumentTest {
 
                 for item in item_set {
                     if let XpathItem::Node(node) = item {
-                        if matches!(node, XpathItemTreeNodeData::DocumentNode(_),) {
+                        if matches!(node, XpathItemTreeNode::DocumentNode(_),) {
                             filtered_nodes.insert(*node);
                         }
                     }

--- a/src/xpath/grammar/types/mod.rs
+++ b/src/xpath/grammar/types/mod.rs
@@ -30,7 +30,7 @@ use super::{
     recipes::Res,
     terminal_symbols::UriQualifiedName,
     xml_names::{nc_name, QName},
-    XpathItemTreeNode, XpathItemTreeNodeData,
+    XpathItemTreeNodeData,
 };
 
 pub mod array_test;
@@ -136,7 +136,7 @@ impl KindTest {
     pub(crate) fn filter<'tree>(
         &self,
         item_set: &XpathItemSet<'tree>,
-    ) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
         match self {
             KindTest::AnyKindTest => {
                 // AnyKindTest is `node()`.
@@ -156,13 +156,7 @@ impl KindTest {
                 // Select all text nodes.
                 let filtered_nodes = item_set.iter().filter_map(|item| {
                     if let XpathItem::Node(node) = item {
-                        if matches!(
-                            node,
-                            XpathItemTreeNode {
-                                data: XpathItemTreeNodeData::TextNode(_),
-                                ..
-                            }
-                        ) {
+                        if matches!(node, XpathItemTreeNodeData::TextNode(_),) {
                             return Some(node.clone());
                         }
                     }
@@ -257,7 +251,7 @@ impl DocumentTest {
     pub(crate) fn filter<'tree>(
         &self,
         item_set: &XpathItemSet<'tree>,
-    ) -> Result<IndexSet<XpathItemTreeNode<'tree>>, ExpressionApplyError> {
+    ) -> Result<IndexSet<&'tree XpathItemTreeNodeData>, ExpressionApplyError> {
         match &self.value {
             // document-node() matches any document node.
             None => {
@@ -265,13 +259,7 @@ impl DocumentTest {
 
                 for item in item_set {
                     if let XpathItem::Node(node) = item {
-                        if matches!(
-                            node,
-                            XpathItemTreeNode {
-                                data: XpathItemTreeNodeData::DocumentNode(_),
-                                ..
-                            }
-                        ) {
+                        if matches!(node, XpathItemTreeNodeData::DocumentNode(_),) {
                             filtered_nodes.insert(node.clone());
                         }
                     }

--- a/src/xpath/mod.rs
+++ b/src/xpath/mod.rs
@@ -4,7 +4,7 @@ use nom::error::VerboseError;
 use thiserror::Error;
 
 use self::{
-    grammar::{data_model::XpathItem, xpath, XpathItemTreeNode},
+    grammar::{data_model::XpathItem, xpath},
     xpath_item_set::XpathItemSet,
 };
 

--- a/src/xpath/xpath_item_set.rs
+++ b/src/xpath/xpath_item_set.rs
@@ -1,6 +1,6 @@
 //! An ordered set of [`XpathItem`]s.
 
-use std::{fmt::Display, ops::Index};
+use std::ops::Index;
 
 use indexmap::{self, IndexSet};
 
@@ -10,16 +10,6 @@ use super::grammar::data_model::{AnyAtomicType, XpathItem};
 #[derive(Debug)]
 pub struct XpathItemSet<'tree> {
     index_set: IndexSet<XpathItem<'tree>>,
-}
-
-impl Display for XpathItemSet<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        let values: Vec<String> = self.iter().map(|item| item.to_string()).collect();
-        let values_str = values.join(", ");
-        write!(f, "{}", values_str)?;
-        write!(f, "]")
-    }
 }
 
 impl PartialEq for XpathItemSet<'_> {

--- a/tests/apply_to_item_tests.rs
+++ b/tests/apply_to_item_tests.rs
@@ -40,11 +40,9 @@ fn apply_to_item_should_select_given_node() {
     assert_eq!(first_expr_item, second_expr_item);
 
     // assert node
-    let tree_node = second_expr_item
-        .extract_into_node()
-        .extract_into_tree_node();
+    let tree_node = second_expr_item.extract_into_node();
 
-    let element = tree_node.data.extract_as_element_node();
+    let element = tree_node.extract_as_element_node();
     assert_eq!(element.name, "body")
 }
 
@@ -90,13 +88,9 @@ fn apply_to_item_slash_should_select_children() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "span");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("1".to_string()));
@@ -104,13 +98,9 @@ fn apply_to_item_slash_should_select_children() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "span");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("2".to_string()));
@@ -118,13 +108,9 @@ fn apply_to_item_slash_should_select_children() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "span");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("3".to_string()));
@@ -173,13 +159,9 @@ fn apply_to_item_double_slash_should_select_self_or_descendents() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "span");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("1".to_string()));
@@ -187,13 +169,9 @@ fn apply_to_item_double_slash_should_select_self_or_descendents() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "span");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("2".to_string()));
@@ -201,13 +179,9 @@ fn apply_to_item_double_slash_should_select_self_or_descendents() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "span");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("3".to_string()));

--- a/tests/contains_tests.rs
+++ b/tests/contains_tests.rs
@@ -29,13 +29,9 @@ fn contains_should_select_text() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
 
         assert_eq!(
@@ -71,13 +67,9 @@ fn contains_should_select_attribute() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
 
         assert_eq!(
@@ -118,13 +110,9 @@ fn contains_should_select_on_expression() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
 
         assert_eq!(

--- a/tests/forward_step_tests.rs
+++ b/tests/forward_step_tests.rs
@@ -19,13 +19,9 @@ fn abbrev_attribute_step_should_match_given_attribute() {
 
     // assert
     assert_eq!(nodes.len(), 1);
-    let attributes: Vec<AttributeNode> = nodes
+    let attributes: Vec<&AttributeNode> = nodes
         .into_iter()
-        .map(|item| {
-            item.extract_into_node()
-                .extract_into_non_tree_node()
-                .extract_into_attribute_node()
-        })
+        .map(|item| item.extract_into_node().extract_as_attribute_node())
         .collect();
 
     // assert attribute

--- a/tests/github_sample_tests.rs
+++ b/tests/github_sample_tests.rs
@@ -1,6 +1,6 @@
 use skyscraper::html::trim_internal_whitespace;
 use skyscraper::xpath::grammar::data_model::TextNode;
-use skyscraper::xpath::grammar::XpathItemTreeNodeData;
+use skyscraper::xpath::grammar::XpathItemTreeNode;
 use skyscraper::{html, xpath};
 
 static HTML: &'static str = include_str!("samples/James-LG_Skyscraper.html");
@@ -83,7 +83,7 @@ fn xpath_github_sample3() {
     let element = tree_node.extract_as_element_node();
     assert_eq!(element.name, "a");
 
-    let children: Vec<&XpathItemTreeNodeData> = tree_node.children(&xpath_item_tree);
+    let children: Vec<&XpathItemTreeNode> = tree_node.children(&xpath_item_tree);
     assert_eq!(children.len(), 2);
     let mut children = children.into_iter();
 

--- a/tests/github_sample_tests.rs
+++ b/tests/github_sample_tests.rs
@@ -1,5 +1,6 @@
 use skyscraper::html::trim_internal_whitespace;
-use skyscraper::xpath::grammar::XpathItemTreeNode;
+use skyscraper::xpath::grammar::data_model::TextNode;
+use skyscraper::xpath::grammar::XpathItemTreeNodeData;
 use skyscraper::{html, xpath};
 
 static HTML: &'static str = include_str!("samples/James-LG_Skyscraper.html");
@@ -20,13 +21,9 @@ fn xpath_github_sample1() {
     assert_eq!(nodes.len(), 1);
     let mut nodes = nodes.into_iter();
 
-    let tree_node = nodes
-        .next()
-        .unwrap()
-        .extract_into_node()
-        .extract_into_tree_node();
+    let tree_node = nodes.next().unwrap().extract_into_node();
 
-    let element = tree_node.data.extract_as_element_node();
+    let element = tree_node.extract_as_element_node();
     assert_eq!(element.name, "main")
 }
 
@@ -46,20 +43,21 @@ fn xpath_github_sample2() {
     assert_eq!(nodes.len(), 5);
     let mut nodes = nodes.into_iter();
 
-    let tree_node = nodes
-        .next()
-        .unwrap()
-        .extract_into_node()
-        .extract_into_tree_node();
+    let tree_node = nodes.next().unwrap().extract_into_node();
 
-    let element = tree_node.data.extract_as_element_node();
+    let element = tree_node.extract_as_element_node();
     assert_eq!(element.name, "a");
 
-    let children: Vec<XpathItemTreeNode> = tree_node.children(&xpath_item_tree).collect();
+    let children: Vec<&TextNode> = tree_node
+        .children(&xpath_item_tree)
+        .into_iter()
+        .filter_map(|x| x.as_text_node().ok())
+        .collect();
+
     assert_eq!(1, children.len());
     let mut children = children.into_iter();
 
-    let text = children.next().unwrap().data.extract_as_text_node();
+    let text = children.next().unwrap();
     assert_eq!(text.content, "refactor: Reorganize into workspace")
 }
 
@@ -80,20 +78,23 @@ fn xpath_github_sample3() {
     assert_eq!(nodes.len(), 1);
     let mut nodes = nodes.into_iter();
 
-    let tree_node = nodes
-        .next()
-        .unwrap()
-        .extract_into_node()
-        .extract_into_tree_node();
+    let tree_node = nodes.next().unwrap().extract_into_node();
 
-    let element = tree_node.data.extract_as_element_node();
+    let element = tree_node.extract_as_element_node();
     assert_eq!(element.name, "a");
 
-    let children: Vec<XpathItemTreeNode> = tree_node.children(&xpath_item_tree).collect();
-    assert_eq!(children.len(), 1);
+    let children: Vec<&XpathItemTreeNodeData> = tree_node.children(&xpath_item_tree);
+    assert_eq!(children.len(), 2);
     let mut children = children.into_iter();
 
-    let text = children.next().unwrap().data.extract_as_text_node();
+    let attribute = children.next().unwrap().extract_as_attribute_node();
+    assert_eq!(attribute.name, "href");
+    assert_eq!(
+        attribute.value,
+        "https://github.com/James-LG/Skyscraper/releases/new"
+    );
+
+    let text = children.next().unwrap().extract_as_text_node();
     assert_eq!(text.content, "Create a new release");
 }
 
@@ -110,7 +111,7 @@ fn xpath_github_sample4() {
     let nodes = xpath.apply(&xpath_item_tree).unwrap();
 
     // assert
-    assert_eq!(nodes.len(), 100);
+    // TODOD assert_eq!(nodes.len(), 100);
 }
 
 #[test]
@@ -129,11 +130,7 @@ fn xpath_github_get_text_sample() {
     assert_eq!(nodes.len(), 1);
     let mut nodes = nodes.into_iter();
 
-    let element = nodes
-        .next()
-        .unwrap()
-        .extract_into_node()
-        .extract_into_tree_node();
+    let element = nodes.next().unwrap().extract_into_node();
 
     let text = element.all_text(&xpath_item_tree).trim().to_string();
     let trimmed_text = trim_internal_whitespace(&text);
@@ -205,15 +202,11 @@ fn xpath_github_get_attributes_sample() {
     assert_eq!(nodes.len(), 1);
     let mut nodes = nodes.into_iter();
 
-    let tree_node = nodes
-        .next()
-        .unwrap()
-        .extract_into_node()
-        .extract_into_tree_node();
-    let elem = tree_node.data.extract_as_element_node();
+    let tree_node = nodes.next().unwrap().extract_into_node();
+    let elem = tree_node.extract_as_element_node();
 
     assert_eq!(
-        elem.get_attribute("class").unwrap(),
+        elem.get_attribute(&xpath_item_tree, "class").unwrap(),
         "flex-auto min-width-0 width-fit mr-3"
     );
 }
@@ -234,13 +227,9 @@ fn xpath_github_root_search() {
     assert_eq!(nodes.len(), 1);
     let mut nodes = nodes.into_iter();
 
-    let tree_node = nodes
-        .next()
-        .unwrap()
-        .extract_into_node()
-        .extract_into_tree_node();
+    let tree_node = nodes.next().unwrap().extract_into_node();
 
-    let element = tree_node.data.extract_as_element_node();
+    let element = tree_node.extract_as_element_node();
     assert_eq!(element.name, "html");
 }
 
@@ -260,13 +249,9 @@ fn xpath_github_root_search_all() {
     assert_eq!(nodes.len(), 1);
     let mut nodes = nodes.into_iter();
 
-    let tree_node = nodes
-        .next()
-        .unwrap()
-        .extract_into_node()
-        .extract_into_tree_node();
+    let tree_node = nodes.next().unwrap().extract_into_node();
 
-    let element = tree_node.data.extract_as_element_node();
+    let element = tree_node.extract_as_element_node();
     assert_eq!(element.name, "html")
 }
 
@@ -286,28 +271,34 @@ fn xpath_github_root_wildcard() {
     assert_eq!(nodes.len(), 16);
 
     // assert first node
-    let tree_node = &nodes[0].extract_as_node().extract_as_tree_node();
-    let elem = tree_node.data.extract_as_element_node();
+    let tree_node = &nodes[0].extract_as_node();
+    let elem = tree_node.extract_as_element_node();
 
     assert_eq!(elem.name, "div");
 
     assert_eq!(
-        elem.get_attribute("class").unwrap(),
+        elem.get_attribute(&xpath_item_tree, "class").unwrap(),
         "position-relative js-header-wrapper "
     );
 
     // assert random node 4
-    let tree_node = &nodes[3].extract_as_node().extract_as_tree_node();
-    let elem = tree_node.data.extract_as_element_node();
+    let tree_node = &nodes[3].extract_as_node();
+    let elem = tree_node.extract_as_element_node();
 
     assert_eq!(elem.name, "include-fragment");
 
     // assert last node
-    let tree_node = &nodes[15].extract_as_node().extract_as_tree_node();
-    let elem = tree_node.data.extract_as_element_node();
+    let tree_node = &nodes[15].extract_as_node();
+    let elem = tree_node.extract_as_element_node();
 
     assert_eq!(elem.name, "div");
 
-    assert_eq!(elem.get_attribute("class").unwrap(), "sr-only");
-    assert_eq!(elem.get_attribute("aria-live").unwrap(), "polite")
+    assert_eq!(
+        elem.get_attribute(&xpath_item_tree, "class").unwrap(),
+        "sr-only"
+    );
+    assert_eq!(
+        elem.get_attribute(&xpath_item_tree, "aria-live").unwrap(),
+        "polite"
+    )
 }

--- a/tests/github_sample_tests.rs
+++ b/tests/github_sample_tests.rs
@@ -111,7 +111,7 @@ fn xpath_github_sample4() {
     let nodes = xpath.apply(&xpath_item_tree).unwrap();
 
     // assert
-    // TODOD assert_eq!(nodes.len(), 100);
+    assert_eq!(nodes.len(), 100);
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn xpath_github_get_text_sample() {
 
     let element = nodes.next().unwrap().extract_into_node();
 
-    let text = element.all_text(&xpath_item_tree).trim().to_string();
+    let text = element.text_content(&xpath_item_tree).trim().to_string();
     let trimmed_text = trim_internal_whitespace(&text);
 
     assert_eq!(trimmed_text, "James-LG / Skyscraper Public");

--- a/tests/lxml_tests.rs
+++ b/tests/lxml_tests.rs
@@ -15,6 +15,7 @@ use skyscraper::{
 struct LxmlElement {
     pub tag: String,
     pub text: Option<String>,
+    pub text_content: String,
     pub attrib: HashMap<String, String>,
     pub itertext: Vec<String>,
 }
@@ -69,11 +70,13 @@ fn skyscraper_to_lxml_elements(
         let node = item.extract_into_node();
         let element = node.extract_as_element_node();
         let text = element.text(&xpath_tree);
+        let text_content = element.text_content(&xpath_tree);
         let itertext = element.itertext(&xpath_tree).collect();
 
         lxml_elements.push(LxmlElement {
             tag: element.name.to_string(),
             text,
+            text_content,
             attrib: element
                 .attributes(&xpath_tree)
                 .iter()

--- a/tests/lxml_tests.rs
+++ b/tests/lxml_tests.rs
@@ -67,16 +67,15 @@ fn skyscraper_to_lxml_elements(
     let mut lxml_elements = Vec::new();
     for item in item_set.into_iter() {
         let node = item.extract_into_node();
-        let tree_node = node.extract_into_tree_node();
-        let element = tree_node.data.extract_as_element_node();
-        let text = tree_node.text(&xpath_tree);
-        let itertext = tree_node.itertext(&xpath_tree).collect();
+        let element = node.extract_as_element_node();
+        let text = element.text(&xpath_tree);
+        let itertext = element.itertext(&xpath_tree).collect();
 
         lxml_elements.push(LxmlElement {
             tag: element.name.to_string(),
             text,
             attrib: element
-                .attributes
+                .attributes(&xpath_tree)
                 .iter()
                 .map(|x| (x.name.clone(), x.value.clone()))
                 .collect(),
@@ -209,9 +208,12 @@ fn test_text_handling3() {
 fn debug_xpath_tree(xpath_item_tree: &XpathItemTree) {
     let xpath_iter = xpath_item_tree.iter();
     for node in xpath_iter {
-        if let Ok(element) = node.data.as_element_node() {
+        if let Ok(element) = node.as_element_node() {
             if element.name == "h2" {
-                println!("{:?}", node.itertext(&xpath_item_tree).collect::<Vec<_>>());
+                println!(
+                    "{:?}",
+                    element.itertext(&xpath_item_tree).collect::<Vec<_>>()
+                );
             }
         }
     }

--- a/tests/lxml_tests/README.md
+++ b/tests/lxml_tests/README.md
@@ -7,5 +7,5 @@ This project is used to test the accepted behaviour of Xpath expressions.
 From the root of the repo, you can create a `test.html` file and pipe it into this Python program along with an Xpath expression as an argument.
 
 ```sh
-cat test.html | python3 tests/lxml_tests/xpath.py "//div[contains(text(),//div[#id='select']/@class)]"
+cat tests/samples/James-LG_Skyscraper.html | python3 tests/lxml_tests/xpath.py "//div"
 ```

--- a/tests/lxml_tests/xpath.py
+++ b/tests/lxml_tests/xpath.py
@@ -4,9 +4,10 @@ import sys
 import lxml.html
 
 class OutputElement:
-    def __init__(self, tag: str, text: str, attrib: dict[str, str], itertext: list[str]):
+    def __init__(self, tag: str, text: str, text_content: str, attrib: dict[str, str], itertext: list[str]):
         self.tag = tag
         self.text = text
+        self.text_content = text_content
         self.attrib = attrib
         self.itertext = itertext
     
@@ -20,6 +21,7 @@ class OutputElement:
         return OutputElement(
             tag=element.tag,
             text=element.text,
+            text_content=element.text_content(),
             attrib=attributes,
             itertext=itertext
         )

--- a/tests/path_tests.rs
+++ b/tests/path_tests.rs
@@ -25,13 +25,9 @@ fn leading_slash_should_select_html_node() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "html");
     }
 }
@@ -68,13 +64,9 @@ fn leading_double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("1".to_string()));
@@ -82,13 +74,9 @@ fn leading_double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("2".to_string()));
@@ -96,13 +84,9 @@ fn leading_double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("3".to_string()));
@@ -110,13 +94,9 @@ fn leading_double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("4".to_string()));
@@ -124,13 +104,9 @@ fn leading_double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("5".to_string()));
@@ -138,13 +114,9 @@ fn leading_double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("6".to_string()));
@@ -187,13 +159,9 @@ fn double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("4".to_string()));
@@ -201,13 +169,9 @@ fn double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("5".to_string()));
@@ -215,13 +179,9 @@ fn double_slash_should_select_all() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(tree_node.text(&xpath_item_tree), Some("6".to_string()));
@@ -255,13 +215,9 @@ fn document_order_preserved_in_results() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element_node = tree_node.data.extract_as_element_node();
+        let element_node = tree_node.extract_as_element_node();
 
         assert_eq!(element_node.name, "span");
 
@@ -270,13 +226,9 @@ fn document_order_preserved_in_results() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element_node = tree_node.data.extract_as_element_node();
+        let element_node = tree_node.extract_as_element_node();
 
         assert_eq!(element_node.name, "span");
 
@@ -288,13 +240,9 @@ fn document_order_preserved_in_results() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element_node = tree_node.data.extract_as_element_node();
+        let element_node = tree_node.extract_as_element_node();
 
         assert_eq!(element_node.name, "span");
 

--- a/tests/predicate_tests.rs
+++ b/tests/predicate_tests.rs
@@ -29,13 +29,9 @@ fn class_equals_predicate_should_select_nodes_with_that_match() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
 
         assert_eq!(
@@ -71,13 +67,9 @@ fn predicate_on_double_leading_slash_should_select_nodes_with_that_match() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
 
         assert_eq!(
@@ -117,13 +109,9 @@ fn index_should_select_indexed_child_for_all_selected_parents() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(
@@ -134,13 +122,9 @@ fn index_should_select_indexed_child_for_all_selected_parents() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(
@@ -180,13 +164,9 @@ fn index_out_of_bounds_should_select_nothing_for_parent() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "p");
 
         assert_eq!(

--- a/tests/reverse_step_tests.rs
+++ b/tests/reverse_step_tests.rs
@@ -22,13 +22,9 @@ fn parent_axis_should_select_parent_node() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "html");
     }
 }
@@ -66,28 +62,20 @@ fn parent_axis_should_select_parents_of_all_selected_nodes() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
-        assert_eq!(element.get_attribute("id"), Some("1"));
+        assert_eq!(element.get_attribute(&xpath_item_tree, "id"), Some("1"));
     }
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
-        assert_eq!(element.get_attribute("id"), Some("2"));
+        assert_eq!(element.get_attribute(&xpath_item_tree, "id"), Some("2"));
     }
 }
 
@@ -125,27 +113,19 @@ fn parent_axis_should_respect_node_test() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
-        assert_eq!(element.get_attribute("id"), Some("1"));
+        assert_eq!(element.get_attribute(&xpath_item_tree, "id"), Some("1"));
     }
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let element = tree_node.data.extract_as_element_node();
+        let element = tree_node.extract_as_element_node();
         assert_eq!(element.name, "div");
-        assert_eq!(element.get_attribute("id"), Some("2"));
+        assert_eq!(element.get_attribute(&xpath_item_tree, "id"), Some("2"));
     }
 }

--- a/tests/static_function_tests.rs
+++ b/tests/static_function_tests.rs
@@ -22,12 +22,8 @@ fn root_should_select_root_node() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        tree_node.data.extract_as_document_node();
+        tree_node.extract_as_document_node();
     }
 }

--- a/tests/treat_tests.rs
+++ b/tests/treat_tests.rs
@@ -39,6 +39,6 @@ fn treat_incorrect_type_should_fail() {
     // assert
     assert_eq!(
         err.to_string(),
-        "Error applying expression err:XPDY0050 Cannot treat [<html/>] as document-node()"
+        "Error applying expression err:XPDY0050 Cannot treat as document-node()"
     );
 }

--- a/tests/type_matching_tests.rs
+++ b/tests/type_matching_tests.rs
@@ -36,7 +36,7 @@ fn text_test_should_match_all_text() {
     // filter out whitespace nodes before testing since they vary by HTML parser.
     let nodes: Vec<_> = nodes
         .into_iter()
-        .filter(|n| match n.extract_as_node().extract_as_tree_node().data {
+        .filter(|n| match n.extract_as_node() {
             XpathItemTreeNodeData::TextNode(text) => !text.only_whitespace,
             _ => true,
         })
@@ -47,73 +47,49 @@ fn text_test_should_match_all_text() {
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let text_node = tree_node.data.extract_as_text_node();
+        let text_node = tree_node.extract_as_text_node();
         assert_eq!(text_node.content, "1");
     }
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let text_node = tree_node.data.extract_as_text_node();
+        let text_node = tree_node.extract_as_text_node();
         assert_eq!(text_node.content, "2");
     }
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let text_node = tree_node.data.extract_as_text_node();
+        let text_node = tree_node.extract_as_text_node();
         assert_eq!(text_node.content, "3");
     }
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let text_node = tree_node.data.extract_as_text_node();
+        let text_node = tree_node.extract_as_text_node();
         assert_eq!(text_node.content, "4");
     }
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let text_node = tree_node.data.extract_as_text_node();
+        let text_node = tree_node.extract_as_text_node();
         assert_eq!(text_node.content, "5");
     }
 
     // assert node
     {
-        let tree_node = nodes
-            .next()
-            .unwrap()
-            .extract_into_node()
-            .extract_into_tree_node();
+        let tree_node = nodes.next().unwrap().extract_into_node();
 
-        let text_node = tree_node.data.extract_as_text_node();
+        let text_node = tree_node.extract_as_text_node();
         assert_eq!(text_node.content, "6");
     }
 }
@@ -134,14 +110,9 @@ fn attribute_test_should_match_all_attributes() {
 
     // assert
     assert_eq!(nodes.len(), 3);
-    let attributes: Vec<AttributeNode> = nodes
+    let attributes: Vec<&AttributeNode> = nodes
         .into_iter()
-        .filter_map(|x| {
-            x.extract_into_node()
-                .extract_into_non_tree_node()
-                .into_attribute_node()
-                .ok()
-        })
+        .filter_map(|x| x.extract_into_node().as_attribute_node().ok())
         .collect();
 
     // assert attribute

--- a/tests/type_matching_tests.rs
+++ b/tests/type_matching_tests.rs
@@ -2,7 +2,7 @@ use skyscraper::{
     html,
     xpath::{
         self,
-        grammar::{data_model::AttributeNode, XpathItemTreeNodeData},
+        grammar::{data_model::AttributeNode, XpathItemTreeNode},
     },
 };
 
@@ -37,7 +37,7 @@ fn text_test_should_match_all_text() {
     let nodes: Vec<_> = nodes
         .into_iter()
         .filter(|n| match n.extract_as_node() {
-            XpathItemTreeNodeData::TextNode(text) => !text.only_whitespace,
+            XpathItemTreeNode::TextNode(text) => !text.only_whitespace,
             _ => true,
         })
         .collect();


### PR DESCRIPTION
Merged tree and non-tree nodes into `XpathItemTreeNode` and moved data into the node itself. This will make it easier to access data in the results of an xpath expression by removing two layers of the data model. 