### PR TITLE
fix(html): Remove println! from tokenizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyscraper"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 authors = ["James La Novara-Gsell <james.lanovara.gsell@gmail.com>"]
 edition = "2021"
 description = "XPath for HTML web scraping"

--- a/src/html/tokenizer/mod.rs
+++ b/src/html/tokenizer/mod.rs
@@ -60,9 +60,6 @@ pub fn lex(text: &str) -> Result<Vec<Token>, LexError> {
             symbols.push(s);
         } else {
             if let Some(c) = pointer.current() {
-                if *c != ' ' {
-                    println!("Unknown symbol {}", c);
-                }
                 if !c.is_whitespace() {
                     // Unknown symbol, move on ¯\_(ツ)_/¯
                     error!("Unknown HTML symbol {}", c);


### PR DESCRIPTION
Print was redundant with an error log being printed right after.

Fixes #43.