### PR TITLE
fix(html): Support all ASCII character escape sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ ordered-float = "4.2.0"
 once_cell = "1.19.0"
 enum-extract-macro = "0.1.1"
 enum-extract-error = "0.1.1"
+regex = "1.10.3"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -27,6 +27,7 @@ use std::{
 use enum_extract_macro::EnumExtract;
 use indextree::{Arena, NodeId};
 use once_cell::sync::Lazy;
+use regex::{Captures, Regex};
 
 pub use crate::html::parse::parse;
 
@@ -156,11 +157,20 @@ impl HtmlText {
 /// - `&quot;` becomes `"`
 /// - `&#39;` becomes `'`
 pub fn unescape_characters(text: &str) -> String {
+    let re = Regex::new(r"&#(\d+);").unwrap();
+    let text = re.replace_all(text, |caps: &Captures| {
+        if let Some(num) = caps.get(1) {
+            if let Ok(num) = num.as_str().parse::<u32>() {
+                return char::from_u32(num).unwrap().to_string();
+            }
+        }
+        return String::new();
+    });
+
     text.replace("&amp;", "&")
         .replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&quot;", r#"""#)
-        .replace("&#39;", "'")
 }
 
 /// Escapes commonly escaped characters in HTML text.

--- a/tests/html_tests.rs
+++ b/tests/html_tests.rs
@@ -36,7 +36,7 @@ fn text_should_include_text_before_between_and_after_child_element() {
 #[test]
 fn text_should_unescape_characters() {
     // arrange
-    let text = r##"<div>&amp;&quot;&#39;&lt;&gt;</div>"##;
+    let text = r##"<div>&amp;&quot;&#39;&lt;&gt;&#96;</div>"##;
 
     // act
     let document = html::parse(text).unwrap();
@@ -47,7 +47,7 @@ fn text_should_unescape_characters() {
 
     let child = children.next().unwrap();
     let html_text = document.get_html_node(&child).unwrap().extract_as_text();
-    assert_eq!(html_text.value, r##"&"'<>"##);
+    assert_eq!(html_text.value, r##"&"'<>`"##);
 }
 
 #[test]


### PR DESCRIPTION
Any ASCII character escape sequence of the format `&#(\d+);` can now be unescaped.