### PR TITLE
add clone to Xpath

### DIFF
--- a/src/xpath/grammar/expressions/mod.rs
+++ b/src/xpath/grammar/expressions/mod.rs
@@ -50,7 +50,7 @@ pub(crate) fn xpath(input: &str) -> Res<&str, Xpath> {
 }
 
 /// An XPath expression.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Xpath(pub Expr);
 
 impl Display for Xpath {


### PR DESCRIPTION
This adds the clone Trait to Xpath so it can be used with the cached macro from the cached crate.

This PR is against 0.6.4 because the master branch currently has some serious performance regressions 
(in my case html parsing takes ~2s instead of ~30ms)