### PR TITLE
fix(html): Reduce calls to unescape_characters which is slow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 test.html
+entities.json

--- a/src/html/parse/mod.rs
+++ b/src/html/parse/mod.rs
@@ -445,7 +445,7 @@ pub mod test_helpers {
         let html_node = document.get_html_node(&key).unwrap();
 
         let node_text = html_node.extract_as_text();
-        assert_eq!(text, node_text.value.trim());
+        assert_eq!(text, node_text.value().trim());
     }
 }
 

--- a/src/xpath/grammar/mod.rs
+++ b/src/xpath/grammar/mod.rs
@@ -21,7 +21,7 @@ pub use expressions::Xpath;
 use indextree::{Arena, NodeId};
 
 use crate::{
-    html::{DocumentNode, HtmlDocument, HtmlNode},
+    html::{unescape_characters, DocumentNode, HtmlDocument, HtmlNode},
     xpath::grammar::data_model::{
         AttributeNode, CommentNode, ElementNode, PINode, TextNode, XpathDocumentNode,
     },
@@ -161,7 +161,8 @@ impl<'a> TextIter<'a> {
         for child in node.children(tree) {
             match child {
                 XpathItemTreeNode::TextNode(text) => {
-                    iter_chain = Box::new(iter_chain.chain(iter::once(text.content.clone())));
+                    let content = unescape_characters(text.content.as_str());
+                    iter_chain = Box::new(iter_chain.chain(iter::once(content)));
                 }
                 XpathItemTreeNode::ElementNode(_child_element) => {
                     iter_chain = Box::new(iter_chain.chain(TextIter::new(tree, child)));

--- a/tests/html_tests.rs
+++ b/tests/html_tests.rs
@@ -1,4 +1,4 @@
-use skyscraper::html;
+use skyscraper::html::{self, unescape_characters};
 
 #[test]
 fn text_should_include_text_before_between_and_after_child_element() {
@@ -47,7 +47,7 @@ fn text_should_unescape_characters() {
 
     let child = children.next().unwrap();
     let html_text = document.get_html_node(&child).unwrap().extract_as_text();
-    assert_eq!(html_text.value, r##"&"'<>`"##);
+    assert_eq!(html_text.value(), r##"&"'<>`"##);
 }
 
 #[test]


### PR DESCRIPTION
The `unescape_characters` method is slow, so the places it is called have been reduced.

Ideally it's performance would be improved, but the html module is in the process of being completely rewritten (#51) so this is just a stop-gap.